### PR TITLE
Address mixed http https content #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Contributions
 This repo is periodically published to:
 
-[rockstor.com](https://https://rockstor.com/)
+[rockstor.com](https://rockstor.com/)
 
-For contribution guidelines, see: [Contributing to Rockstor documentation](http://rockstor.com/docs/contribute_documentation.html)
+For contribution guidelines, see: [Contributing to Rockstor documentation](https://rockstor.com/docs/contribute_documentation.html)
 
 # History
 This website was initially developed using a Python based static site generator believed to be [hyde](https://github.com/hyde/hyde).

--- a/about-us.html
+++ b/about-us.html
@@ -72,7 +72,7 @@
               <li><a href="about-us.html#contact">Contact</a></li>
             </ul>
           </li>
-          <li><a href="http://shop.rockstor.com" target="_blank">Shop</a></li>
+          <li><a href="https://shop.rockstor.com" target="_blank">Shop</a></li>
           <li><a class="btn-down" href="/download.html">Download</a></li>
           <li>
             <ul class="social_icons">

--- a/commercial_support.html
+++ b/commercial_support.html
@@ -72,7 +72,7 @@
               <li><a href="about-us.html#contact">Contact</a></li>
             </ul>
           </li>
-          <li><a href="http://shop.rockstor.com" target="_blank">Shop</a></li>
+          <li><a href="https://shop.rockstor.com" target="_blank">Shop</a></li>
           <li><a class="btn-down" href="/download.html">Download</a></li>
           <li>
             <ul class="social_icons">
@@ -105,14 +105,15 @@
         <p class="lead">
           Purchase Rockstor support for direct access to our engineers. Targeted response time 48 hours, see support FAQ below. We aim to: complement
           your existing IT resources, and minimise down time.</p> <em>We are here to help.</em>
-        <!--      <a class="btn-primary" href="http://shop.rockstor.com/collections/services/products/incident-based-support" target="_blank">Buy Now</a>-->
+        <!--      <a class="btn-primary" href="https://shop.rockstor.com/collections/services/products/incident-based-support" target="_blank">Buy
+        Now</a>-->
       </div>
       <div class="row">
         <div class="subdetails" id="subdetails">
           <h2>Subscription details</h2>
           <p>
             A Rockstor Incident-Based support subscription is a flexible pay-as-you-go add-on for <a
-              href="http://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank"
+              href="https://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank"
               class="link-highlight">Stable Channel</a> subscribers. An incident is defined as a question relating to a specific, discrete issue, and
             may involve several interactions with the Rockstor team prior to that issue's resolution.
           </p><br>

--- a/customizable-btrfs-nas-storage-platform.html
+++ b/customizable-btrfs-nas-storage-platform.html
@@ -72,7 +72,7 @@
               <li><a href="about-us.html#contact">Contact</a></li>
             </ul>
           </li>
-          <li><a href="http://shop.rockstor.com" target="_blank">Shop</a></li>
+          <li><a href="https://shop.rockstor.com" target="_blank">Shop</a></li>
           <li><a class="btn-down" href="/download.html">Download</a></li>
           <li>
             <ul class="social_icons">

--- a/download.html
+++ b/download.html
@@ -72,7 +72,7 @@
               <li><a href="about-us.html#contact">Contact</a></li>
             </ul>
           </li>
-          <li><a href="http://shop.rockstor.com" target="_blank">Shop</a></li>
+          <li><a href="https://shop.rockstor.com" target="_blank">Shop</a></li>
           <li><a class="btn-down" href="/download.html">Download</a></li>
           <li>
             <ul class="social_icons">

--- a/features.html
+++ b/features.html
@@ -72,7 +72,7 @@
               <li><a href="about-us.html#contact">Contact</a></li>
             </ul>
           </li>
-          <li><a href="http://shop.rockstor.com" target="_blank">Shop</a></li>
+          <li><a href="https://shop.rockstor.com" target="_blank">Shop</a></li>
           <li><a class="btn-down" href="/download.html">Download</a></li>
           <li>
             <ul class="social_icons">

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
               <li><a href="about-us.html#contact">Contact</a></li>
             </ul>
           </li>
-          <li><a href="http://shop.rockstor.com" target="_blank">Shop</a></li>
+          <li><a href="https://shop.rockstor.com" target="_blank">Shop</a></li>
           <li><a class="btn-down" href="/download.html">Download</a></li>
           <li>
             <ul class="social_icons">
@@ -504,7 +504,7 @@
     <div class="partners">
       <ul>
         <li>
-          <a href="http://www.45drives.com" target="_blank"> <img class="img-responsive wow fadeInDown"
+          <a href="https://www.45drives.com" target="_blank"> <img class="img-responsive wow fadeInDown"
                                                                   data-wow-duration="1000ms" data-wow-delay="300ms"
                                                                   src="/media/images/45drives.jpg"> </a>
         </li>

--- a/legal.html
+++ b/legal.html
@@ -72,7 +72,7 @@
               <li><a href="about-us.html#contact">Contact</a></li>
             </ul>
           </li>
-          <li><a href="http://shop.rockstor.com" target="_blank">Shop</a></li>
+          <li><a href="https://shop.rockstor.com" target="_blank">Shop</a></li>
           <li><a class="btn-down" href="/download.html">Download</a></li>
           <li>
             <ul class="social_icons">

--- a/linux-btrfs-nas-server.html
+++ b/linux-btrfs-nas-server.html
@@ -72,7 +72,7 @@
               <li><a href="about-us.html#contact">Contact</a></li>
             </ul>
           </li>
-          <li><a href="http://shop.rockstor.com" target="_blank">Shop</a></li>
+          <li><a href="https://shop.rockstor.com" target="_blank">Shop</a></li>
           <li><a class="btn-down" href="/download.html">Download</a></li>
           <li>
             <ul class="social_icons">

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -1,4 +1,3 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,600,700,300,800);
 
 
 /*************************

--- a/media/css/majorColorChange.css
+++ b/media/css/majorColorChange.css
@@ -1,4 +1,3 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,600,700,300,800);
 
 
 /*************************

--- a/personal-cloud-btrfs-nas-server.html
+++ b/personal-cloud-btrfs-nas-server.html
@@ -72,7 +72,7 @@
               <li><a href="about-us.html#contact">Contact</a></li>
             </ul>
           </li>
-          <li><a href="http://shop.rockstor.com" target="_blank">Shop</a></li>
+          <li><a href="https://shop.rockstor.com" target="_blank">Shop</a></li>
           <li><a class="btn-down" href="/download.html">Download</a></li>
           <li>
             <ul class="social_icons">

--- a/privacy_policy.html
+++ b/privacy_policy.html
@@ -74,7 +74,7 @@
               <li><a href="about-us.html#contact">Contact</a></li>
             </ul>
           </li>
-          <li><a href="http://shop.rockstor.com" target="_blank">Shop</a></li>
+          <li><a href="https://shop.rockstor.com" target="_blank">Shop</a></li>
           <li><a class="btn-down" href="/download.html">Download</a></li>
           <li>
             <ul class="social_icons">

--- a/smb-private-cloud-btrfs-nas-server.html
+++ b/smb-private-cloud-btrfs-nas-server.html
@@ -72,7 +72,7 @@
               <li><a href="about-us.html#contact">Contact</a></li>
             </ul>
           </li>
-          <li><a href="http://shop.rockstor.com" target="_blank">Shop</a></li>
+          <li><a href="https://shop.rockstor.com" target="_blank">Shop</a></li>
           <li><a class="btn-down" href="/download.html">Download</a></li>
           <li>
             <ul class="social_icons">


### PR DESCRIPTION
Following our move to https hosting we need to similarly normalise our links where possible. Especially where they are otherwise dysfunctional in more modern browsers due to mixed content protections.

Fixes #2 

## Includes:
- fix typo in rockstor.com https link
- move external shop.rockstor.com links to https
- move remaining explicit external http links to https
- remove unused http fonts.googleapis.com imports

## Testing:
Prior to the changes presented here we had the following 'blocker' content that instigated the issue:
```
Blocked loading mixed active content “http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,600,700,300,800”
```
Post proposed changes this error was not in evidence.

All modified pages/links were confirmed as displaying/linking as intended under an https hosting environment.
