### PR TITLE
Add Rockstor 4 installer download place-holder links #7

### DIFF
--- a/download.html
+++ b/download.html
@@ -96,25 +96,28 @@
 
   <section id="about-us">
     <div class="container">
-      <div class="center wow fadeInDown">
-        <br>
-      </div>
+      <br>
       <div class="center col-md-12">
-        <p class="lead">
-          Download using the options below.
-        </p>
+        <h3>Install using the options below.
+          <br>
+          Pre-built Rockstor 4 installers are pending Stable status.
+        </h3>
+        <i>Rockstor 4.0.7-0 = Stable Release Candidate 8 (recommended for new installs).</i>
+        <br>
+        <b>Rockstor 4 is now Pi4 & ARM64 Embedded Boot / Server Boot compatible.</b>
       </div>
       <div class="col-sm-offset-2 col-sm-8 col-sm-offset-2">
         <div class="row">
+
           <div class="col-md-6">
             <a href="https://sourceforge.net/projects/rockstor/files" target="_blank">
               <div class="media download-wrap wow fadeInDown">
                 <div class="media-body">
                   <div class="col-sm-8">
-                    <h2 class="media-heading">SourceForge</h2>
+                    <h2 class="media-heading">Rockstor 3 CentOS based</h2>
                     <p>
-                      Files Page for CentOS<br>
-                      based ISO installer
+                      <br>
+                      Near legacy ISO installer (2017) Last Stable v3.9.2-57 (April 2020)
                     </p>
                   </div>
                   <div class="col-sm-4"><img src="/media/images/sf.jpeg" width="70px;" height="70px;"></img></div>
@@ -122,6 +125,24 @@
               </div>
             </a>
           </div>
+
+          <div class="col-md-6">
+            <a href="https://github.com/rockstor/rockstor-installer" target="_blank">
+              <div class="media download-wrap wow fadeInDown">
+                <div class="media-body">
+                  <div class="col-sm-8">
+                    <h2 class="media-heading">Rockstor 4 "Built on openSUSE"</h2>
+                    <p>
+                      <br>
+                      Stable Release Candidate v4.0.7 (2021) Build your own installer
+                    </p>
+                  </div>
+                  <div class="col-sm-4"><img src="/media/images/GitHub_Logo.png" width="70px;" height="70px;"></img></div>
+                </div>
+              </div>
+            </a>
+          </div>
+
         </div><!-- closing row-->
       </div><!-- closing the outermost div -->
       <br/><br/>


### PR DESCRIPTION
As we are now at release candidate 8 (4.0.7-0) it makes sense to broaden our surfacing of the Rockstor 4 DIY installer option. Here we also introduce the new Rockstor 4 ARM64 compatibility as this may inform folks choice further. Given the age of our CentOS based installer and it's last Stable release being around a year old, we recommend 4 for new installs.

Fixes #7 
@FroggyFlox Ready for review

## Testing:
Rendering was tested in both Firefox and Chrome, all looked to be as expected.
A comment will follow with a Firefox screenshot.