### PR TITLE
Update base OS info re new Rockstor 4 variant #17

### DIFF
--- a/linux-btrfs-nas-server.html
+++ b/linux-btrfs-nas-server.html
@@ -148,7 +148,7 @@
           </p>
           <h4>Solution:</h4>
           <p class="lead">
-            Rockstor, the first Linux BTRFS NAS software appliance, aims to combines flexibility & ease-of-use.
+            Rockstor, the first Linux BTRFS NAS software appliance, aims to combine flexibility & ease-of-use.
             Generic commodity hardware, both <b>X86_64 and ARM64 (e.g. Pi4)</b>, can easily be up and running within minutes.
             <b>Rockstor 4 is "Built on openSUSE"</b> while our near legacy 3 and older versions used CentOS 7 with newer elrepo kernels.
             Once installed all maintenance is via Rockstor's Web-UI: good for NAS/linux beginners and pros alike.

--- a/linux-btrfs-nas-server.html
+++ b/linux-btrfs-nas-server.html
@@ -148,9 +148,10 @@
           </p>
           <h4>Solution:</h4>
           <p class="lead">
-            Rockstor is the first Linux, BTRFS based NAS distribution to help users build and maintain a NAS server with least effort. It's based on
-            CentOS 7, but comes with a later kernel from Elrepo and can be installed on commodity hardware. Once installed, all maintenance can be
-            done using Rockstor's web-ui which doesn't expect the user to be a Linux Pro.
+            Rockstor, the first Linux BTRFS NAS software appliance, aims to combines flexibility & ease-of-use.
+            Generic commodity hardware, both <b>X86_64 and ARM64 (e.g. Pi4)</b>, can easily be up and running within minutes.
+            <b>Rockstor 4 is "Built on openSUSE"</b> while our near legacy 3 and older versions used CentOS 7 with newer elrepo kernels.
+            Once installed all maintenance is via Rockstor's Web-UI: good for NAS/linux beginners and pros alike.
           </p>
         </div>
         <div class="col-sm-12">

--- a/linux-btrfs-nas-server.html
+++ b/linux-btrfs-nas-server.html
@@ -151,7 +151,7 @@
             Rockstor, the first Linux BTRFS NAS software appliance, aims to combine flexibility & ease-of-use.
             Generic commodity hardware, both <b>X86_64 and ARM64 (e.g. Pi4)</b>, can easily be up and running within minutes.
             <b>Rockstor 4 is "Built on openSUSE"</b> while our near legacy 3 and older versions used CentOS 7 with newer elrepo kernels.
-            Once installed all maintenance is via Rockstor's Web-UI: good for NAS/linux beginners and pros alike.
+            Once installed, all maintenance is done via Rockstor's Web-UI: good for NAS/linux beginners and pros alike.
           </p>
         </div>
         <div class="col-sm-12">

--- a/linux-btrfs-nas-server.html
+++ b/linux-btrfs-nas-server.html
@@ -149,7 +149,7 @@
           <h4>Solution:</h4>
           <p class="lead">
             Rockstor, the first Linux BTRFS NAS software appliance, aims to combine flexibility & ease-of-use.
-            Generic commodity hardware, both <b>X86_64 and ARM64 (e.g. Pi4)</b>, can easily be up and running within minutes.
+            Generic commodity hardware, both <b>X86_64 and ARM64 (e.g. Raspberyy Pi 4)</b>, can easily be up and running within minutes.
             <b>Rockstor 4 is "Built on openSUSE"</b> while our near legacy 3 and older versions used CentOS 7 with newer elrepo kernels.
             Once installed, all maintenance is done via Rockstor's Web-UI: good for NAS/linux beginners and pros alike.
           </p>


### PR DESCRIPTION
Add a "Built on openSUSE" phrase to show our new base OS for the new Rockstor 4 endeavour. Includes minor rewording and reference to the now broader architecture support, i.e. the ARM64 / Pi4 platforms.

Fixes #17 
Ready for review

Includes additional bold formatting to help draw attention to our newer base OS and architecture capabilities.

Testing:
Rendered as expected in Chrome and Firefox.
Firefox screen capture to follow in comments.