### PR TITLE
Change recommended new installs to 4.0.8-0 #19

### DIFF
--- a/download.html
+++ b/download.html
@@ -102,7 +102,7 @@
           <br>
           Pre-built Rockstor 4 installers are pending Stable status.
         </h3>
-        <i>Rockstor 4.0.7-0 = Stable Release Candidate 8 (recommended for new installs).</i>
+        <i>Rockstor 4.0.8-0 = Stable Release Candidate 9 (recommended for new installs).</i>
         <br>
         <b>Rockstor 4 is now Pi4 & ARM64 Embedded Boot / Server Boot compatible.</b>
       </div>
@@ -134,7 +134,7 @@
                     <h2 class="media-heading">Rockstor 4 "Built on openSUSE"</h2>
                     <p>
                       <br>
-                      Stable Release Candidate v4.0.7 (2021) Build your own installer
+                      Stable Release Candidate 4.0.8-0 (2021) Build your own installer
                     </p>
                   </div>
                   <div class="col-sm-4"><img src="/media/images/GitHub_Logo.png" width="70px;" height="70px;"></img></div>


### PR DESCRIPTION
We then start folk off with the https Rock-on definition retrieval as the old http one with our newer https stance, and consequent http->https redirect failed in some slower network settings.

Fixes #19 
