### PR TITLE
Normalise on button class "about_btn" #24

### DIFF
--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -1,5 +1,5 @@
 {{ if and (.Get "label") (.Get "link") }}
-<a class="btn-down" href="{{ .Get `link` }}" target="_blank">{{ .Get "label" }}</a>
+<a class="about_btn" href="{{ .Get `link` }}" target="_blank">{{ .Get "label" }}</a>
 {{ else }}
 {{ errorf "missing value for param: %s" .Position }}
 {{ end }}


### PR DESCRIPTION
The existing button.html shortcode used class="btn-down" which was dis-functional and not in keeping with the functional home page buttons which used the about_btn class. This way we have less maintenance surface in the inevitable css clean-up to follow.

Fixes #24 

## Testing:
### default post pr:
![post-pr-default](https://user-images.githubusercontent.com/2521585/140615945-2fedd0f5-4b99-4891-b6db-0d9fdbb71427.png)

### hover:
![post-pr-hover](https://user-images.githubusercontent.com/2521585/140615962-a3b2d8f4-379e-46fb-8d30-fa889c6d7332.png)

### previously clicked:
![post-pr-clicked](https://user-images.githubusercontent.com/2521585/140615971-d91efd2a-92fe-4fc6-a970-694851dcd408.png)


