### PR TITLE
Add EULA link & update page to account for v4 "Built on openSUSE" #4

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -72,7 +72,7 @@ hasChildren = true
   url = "/docs/faq.html"
   weight = 2
 
-    [[menu.main]]
+  [[menu.main]]
   parent = "Resources"
   name = "Quick Start"
   url = "/docs/quickstart.html"
@@ -86,9 +86,15 @@ hasChildren = true
 
   [[menu.main]]
   parent = "Resources"
+  name = "EULA"
+  PageRef = "eula.md"
+  weight = 5
+
+  [[menu.main]]
+  parent = "Resources"
   name = "Commercial Support"
   PageRef = "commercial_support.md"
-  weight = 5
+  weight = 6
 
 [[menu.main]]
 name = "Community"

--- a/content/eula.md
+++ b/content/eula.md
@@ -10,3 +10,122 @@ Rockstor comes with no guarantees or warranties of any sorts, either written or 
 The Distribution is released as GPLv2.
 Individual packages in the distribution come with their own licences.
 A copy of the GPLv2 license is included with the distribution media.
+
+---
+## Our V4 "Built on openSUSE" EULA
+The following is a Trademarks search/replace of our new upstream (openSUSE) GPLv2 license.
+And is the same as that displayed / agreed-to during our [kiwi-ng](https://github.com/OSInside/kiwi) created installer.
+See the following file in our [rockstor-installer](https://github.com/rockstor/rockstor-installer/blob/master/config.sh) repository.
+
+As indicated in [openSUSE:Trademark guidelines](https://en.opensuse.org/openSUSE:Trademark_guidelines) we are required to make these changes.
+We are also required to us one of the preferred terms when referencing our new upstream base and we have chosen to use: **Built on openSUSE** & **Uses openSUSE**.
+Examples of this use during the installer can be seen in our [Rockstor’s “Built on openSUSE” installer](https://rockstor.com/docs/installation/installer-howto.html) document section.
+
+We thank openSUSE / SuSE and the wider open source community for such excellent resources as the Leap base we use, [kiwk-ng](https://github.com/OSInside/kiwi), and the [Open Build Service (OBS)](https://build.opensuse.org/).
+
+---
+
+LICENSE AGREEMENT
+Rockstor® Leap 15.3
+
+This agreement governs your download, installation, or use
+of Rockstor Leap 15.3 and its updates, regardless of the delivery
+mechanism. Rockstor Leap 15.3 is a collective work under US Copyright
+Law. Subject to the following terms, The Rockstor Project grants to
+you a license to this collective work pursuant to the GNU General
+Public License version 2. By downloading, installing, or using
+Rockstor Leap 15.3, you agree to the terms of this agreement.
+
+Rockstor Leap 15.3 is a modular Linux operating system consisting of
+hundreds of software components. The license agreement for each
+component is generally located in the component's source code. With
+the exception of certain files containing the “Rockstor”
+trademark discussed below, the license terms for the components
+permit you to copy and redistribute the component. With the
+potential exception of certain firmware files, the license terms
+for the components permit you to copy, modify, and redistribute the
+component, in both source code and binary code forms. This agreement
+does not limit your rights under, or grant you rights that supersede,
+the license terms of any particular component.
+
+Rockstor Leap 15.3 and each of its components, including the source
+code, documentation, appearance, structure, and organization, are
+copyrighted by The Rockstor Project and others and are protected under
+copyright and other laws. Title to Rockstor Leap 15.3 and any
+component, or to any copy, will remain with the aforementioned or its
+licensors, subject to the applicable license. The "Rockstor" trademark
+is a trademark of Rockstor, Inc. in the US and other countries and is
+used by permission. This agreement permits you to distribute
+unmodified or modified copies of Rockstor Leap 15.3 using the
+“Rockstor” trademark on the condition that you follow The Rockstor
+Project’s trademark guidelines located at
+http://rockstor.com/legal.html. You must abide by these trademark
+guidelines when distributing Rockstor Leap 15.3, regardless of whether
+Rockstor Leap 15.3 has been modified.
+
+Except as specifically stated in this agreement or a license for
+a particular component, TO THE MAXIMUM EXTENT PERMITTED UNDER
+APPLICABLE LAW, ROCKSTOR Leap 15.3 AND THE COMPONENTS ARE PROVIDED
+AND LICENSED "AS IS" WITHOUT WARRANTY OF ANY KIND, EXPRESSED OR
+IMPLIED, INCLUDING THE IMPLIED WARRANTIES OF MERCHANTABILITY, TITLE,
+NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE. The Rockstor
+Project does not warrant that the functions contained in Rockstor
+Leap 15.3 will meet your requirements or that the operation of Rockstor
+Leap 15.3 will be entirely error free or appear precisely as described
+in the accompanying documentation. USE OF ROCKSTOR Leap 15.3 IS AT YOUR
+OWN RISK.
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE ROCKSTOR
+PROJECT (AND ITS LICENSORS, SUBSIDIARIES, AND EMPLOYEES) WILL NOT
+BE LIABLE TO YOU FOR ANY DAMAGES, INCLUDING DIRECT, INCIDENTAL,
+OR CONSEQUENTIAL DAMAGES, LOST PROFITS, OR LOST SAVINGS ARISING OUT
+OF THE USE OR INABILITY TO USE ROCKSTOR Leap 15.3, EVEN IF THE ROCKSTOR
+PROJECT HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.  IN A
+JURISDICTION THAT LIMITS THE EXCLUSION OR LIMITATION OF DAMAGES,
+THE ROCKSTOR PROJECT’S (AND ITS LICENSORS’, SUBSIDIARIES’, AND
+EMPLOYEES’) AGGREGATE LIABILITY IS LIMITED TO $24US, OR IF SUCH A
+LIMITATION IS NOT ALLOWED, IS LIMITED TO THE MAXIMUM EXTENT ALLOWED.
+
+You acknowledge that Rockstor Leap 15.3 is subject to the U.S. Export
+Administration Regulations (the “EAR”) and you agree to comply with the
+EAR.  You will not export or re-export Rockstor Leap 15.3 directly or
+indirectly, to: (1) any countries that are subject to US export
+restrictions; (2) any end user who you know or have reason to know will
+utilize Rockstor Leap 15.3 in the design, development or production of
+nuclear, chemical or biological weapons, or rocket systems, space launch
+vehicles, and sounding rockets, or unmanned air vehicle systems, except
+as authorized by the relevant government agency by regulation or specific
+license; or (3) any end user who has been prohibited from participating in
+the US export transactions by any federal agency of the US government. By
+downloading or using Rockstor Leap 15.3, you are agreeing to the foregoing
+and you are representing and warranting that You are not located in,under
+the control of, or a national or resident of any such country or on any
+such list. In addition, you are responsible for complying with any local laws
+in Your jurisdiction which may impact Your right to import, export or use
+Rockstor Leap 15.3.  Please consult the Bureau of Industry and Security web
+page www.bis.doc.gov before exporting items subject to the EAR. It is your
+responsibility to obtain any necessary export approvals.
+
+If any provision of this agreement is held to be unenforceable, that
+will not affect the enforceability of the remaining provisions. This
+agreement will be governed by the laws of the State of Utah and
+of the US, without regard to any conflict of laws provisions,
+except that the United Nations Convention on the International
+Sale of Goods will not apply. This agreement sets forth the entire
+understanding and agreement between you and The Rockstor Project
+regarding its subject matter and may be amended only in a writing
+signed by both parties. No waiver of any right under this agreement
+will be effective unless in writing, signed by a duly authorized
+representative of the party to be bound. No waiver of any past or
+present right arising from any breach or failure to perform will
+be deemed to be a waiver of any future right arising under this
+agreement. Use, duplication, or disclosure by the U.S. Government
+is subject to the restrictions in FAR 52.227-14 (Dec 2007)
+Alternate III (Dec 2007), FAR  52.227-19 (Dec 2007), or DFARS
+252.227-7013(b)(3) (Nov 1995), or applicable successor clauses.
+
+Copyright © 2008-2021 The Rockstor Project. All rights
+reserved. "Store Smartly" and "Rockstor" are registered trademarks of Rockstor, Inc.,
+or its affiliates, which founded, sponsors, and is designated by, The Rockstor
+Project. "Linux" is a registered trademark of Linus Torvalds. All
+other trademarks are the property of their respective owners.


### PR DESCRIPTION
Currently only contains english version but other versions can be included once we move to a multi-lingual site. Also note that in this case alone we maintain exact formatting of the eula text as it is then easier to verify against it's canonical version held in:

/usr/share/licenses/openSUSE-release

Fixes #4 
