### PR TITLE
Update EULA re minor changes in installer #27

### DIFF
--- a/content/eula.md
+++ b/content/eula.md
@@ -18,7 +18,7 @@ And is the same as that displayed / agreed-to during our [kiwi-ng](https://githu
 See the following file in our [rockstor-installer](https://github.com/rockstor/rockstor-installer/blob/master/config.sh) repository.
 
 As indicated in [openSUSE:Trademark guidelines](https://en.opensuse.org/openSUSE:Trademark_guidelines) we are required to make these changes.
-We are also required to us one of the preferred terms when referencing our new upstream base and we have chosen to use: **Built on openSUSE** & **Uses openSUSE**.
+We are also required to use one of the given terms when referencing our new upstream: we have chosen to use: **Built on openSUSE** & **Uses openSUSE**.
 Examples of this use during the installer can be seen in our [Rockstor’s “Built on openSUSE” installer](https://rockstor.com/docs/installation/installer-howto.html) document section.
 
 We thank openSUSE / SuSE and the wider open source community for such excellent resources as the Leap base we use, [kiwk-ng](https://github.com/OSInside/kiwi), and the [Open Build Service (OBS)](https://build.opensuse.org/).

--- a/content/eula.md
+++ b/content/eula.md
@@ -59,7 +59,7 @@ used by permission. This agreement permits you to distribute
 unmodified or modified copies of Rockstor Leap 15.3 using the
 “Rockstor” trademark on the condition that you follow The Rockstor
 Project’s trademark guidelines located at
-http://rockstor.com/legal.html. You must abide by these trademark
+https://rockstor.com/legal.html. You must abide by these trademark
 guidelines when distributing Rockstor Leap 15.3, regardless of whether
 Rockstor Leap 15.3 has been modified.
 
@@ -83,7 +83,7 @@ OF THE USE OR INABILITY TO USE ROCKSTOR Leap 15.3, EVEN IF THE ROCKSTOR
 PROJECT HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.  IN A
 JURISDICTION THAT LIMITS THE EXCLUSION OR LIMITATION OF DAMAGES,
 THE ROCKSTOR PROJECT’S (AND ITS LICENSORS’, SUBSIDIARIES’, AND
-EMPLOYEES’) AGGREGATE LIABILITY IS LIMITED TO $24US, OR IF SUCH A
+EMPLOYEES’) AGGREGATE LIABILITY IS LIMITED TO 1ST SUBSCRIPTION PAYED, OR IF SUCH A
 LIMITATION IS NOT ALLOWED, IS LIMITED TO THE MAXIMUM EXTENT ALLOWED.
 
 You acknowledge that Rockstor Leap 15.3 is subject to the U.S. Export
@@ -124,7 +124,7 @@ is subject to the restrictions in FAR 52.227-14 (Dec 2007)
 Alternate III (Dec 2007), FAR  52.227-19 (Dec 2007), or DFARS
 252.227-7013(b)(3) (Nov 1995), or applicable successor clauses.
 
-Copyright © 2008-2021 The Rockstor Project. All rights
+Copyright © 2012-2021 The Rockstor Project. All rights
 reserved. "Store Smartly" and "Rockstor" are registered trademarks of Rockstor, Inc.,
 or its affiliates, which founded, sponsors, and is designated by, The Rockstor
 Project. "Linux" is a registered trademark of Linus Torvalds. All


### PR DESCRIPTION
Please see the partner pull request and issue in our rockstor-installer repo:
pull request: https://github.com/rockstor/rockstor-installer/pull/84
issue: https://github.com/rockstor/rockstor-installer/issues/83
for context.

Fixes #27

## Includes:
- http to https for legal page reference.
- removal of hard coded liability dollar amount in favour of linking to 1st subscription payed.
- update of copyright dates.

Overall this change simply reflects the new filters applied to our upstream license by our installer.