### PR TITLE
Remove installer links based on the now EOL 15.2 OS base #30

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -157,7 +157,7 @@ author = "See: AUTHORS file."
 # Website copyright notice (markdownify)
 copyright = "Copyright &copy; 2021 Rockstor inc."
 # use lowercase version of frontmatter os
-downloads_os_order = ["leap15.3","leap15.2", "diy", "centos7.1511", "rpm"]
+downloads_os_order = ["leap15.3", "diy", "centos7.1511", "rpm"]
 
 # CSS Plugins
 [[params.plugins.css]]


### PR DESCRIPTION
Via Hugo config.toml custom config option controlling which os options we list, and in what order, on the downloads page.

Fixes #30 