### PR TITLE
Update downloads page re installer version and RC status #32

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -157,7 +157,7 @@ author = "See: AUTHORS file."
 # Website copyright notice (markdownify)
 copyright = "Copyright &copy; 2021 Rockstor inc."
 # use lowercase version of frontmatter os
-downloads_os_order = ["leap15.3", "diy", "centos7.1511", "rpm"]
+downloads_os_order = ["leap15.3", "diy", "rpm", "centos7.1511"]
 
 # CSS Plugins
 [[params.plugins.css]]

--- a/config.toml
+++ b/config.toml
@@ -155,7 +155,7 @@ downloadsserver = "https://rockstor.com/"
 logo = "images/rockstorlogo-font2.png"
 author = "See: AUTHORS file."
 # Website copyright notice (markdownify)
-copyright = "Copyright &copy; 2021 Rockstor inc."
+copyright = "Copyright &copy; 2022 Rockstor inc."
 # use lowercase version of frontmatter os
 downloads_os_order = ["leap15.3", "diy", "rpm", "centos7.1511"]
 

--- a/content/dls/CentOS7-1511_x86_64.md
+++ b/content/dls/CentOS7-1511_x86_64.md
@@ -17,7 +17,7 @@ Legacy / Unsupported installer from 2017. Available here only for specialist pur
 
 Also available on SourceForge as [Rockstor-3.9.1.iso](https://sourceforge.net/projects/rockstor/files/)
 
-**Do not use for new installs.**
+**DO NOT USE FOR NEW INSTALLS.**
 
 - Last Testing Channel release (3.9.1-16) - November 2017
 - Last Stable channel released (3.9.2-57) - April 2020 

--- a/content/dls/Leap15-3_ARM64EFI.md
+++ b/content/dls/Leap15-3_ARM64EFI.md
@@ -8,9 +8,11 @@ os: "Leap15.3"
 os_weight: 50
 machine: "ARM64EFI"
 arch: "aarch64"
-rpm_version: "4.0.9"
+rpm_version: "4.1.0"
 rpm_release: "0"
 installer_patch: ""
 ---
 
 Awaiting Custom Ten64 drivers.
+Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
+for improved hardware compatibility.

--- a/content/dls/Leap15-3_RaspberryPi4.md
+++ b/content/dls/Leap15-3_RaspberryPi4.md
@@ -8,9 +8,9 @@ os: "Leap15.3"
 os_weight: 50
 machine: "RaspberryPi4"
 arch: "aarch64"
-rpm_version: "4.0.9"
+rpm_version: "4.1.0"
 rpm_release: "0"
 installer_patch: ""
 ---
 
-Recommended for Pi 400.
+Also Pi 400 compatible.

--- a/content/dls/Leap15-3_x86_64.md
+++ b/content/dls/Leap15-3_x86_64.md
@@ -8,9 +8,14 @@ os: "Leap15.3"
 os_weight: 50
 machine: "generic"
 arch: "x86_64"
-rpm_version: "4.0.9"
+rpm_version: "4.1.0"
 rpm_release: "0"
 installer_patch: ""
 ---
 
 **Recommended**
+
+**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+
+Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
+to enable parity raid read-write access.

--- a/content/dls/_index.md
+++ b/content/dls/_index.md
@@ -15,9 +15,9 @@ cascade:
 {{< center-this >}}
 ## Install using the options below.
 
-## Pre-built Rockstor 4 installers are Release Candidate 10.
+## "Built on openSUSE" installers use 1st v4 Stable release.
 
-*Rockstor 4.0.9-0 = Stable Release Candidate 10 (recommended for new installs)*
+*Rockstor 4.1.0-0 = First "Built on openSUSE" Stable Release*
 
 *Rockstor 4 is now also Pi4 & ARM64 [Embedded Boot](https://github.com/ARM-software/ebbr) / [Server Boot](https://github.com/ARM-software/sbsa-acs) compatible.*
 

--- a/content/dls/diy.md
+++ b/content/dls/diy.md
@@ -8,7 +8,7 @@ os: "diy"
 os_weight: 40
 machine: "generic|RaspberryPi4|ARM64EFI"
 arch: "x86_64|aarch64"
-rpm_version: "4.0.9"
+rpm_version: "4.1.0"
 rpm_release: "0"
 installer_patch: ""
 ---

--- a/content/dls/rpm.md
+++ b/content/dls/rpm.md
@@ -8,7 +8,7 @@ os: "rpm"
 os_weight: 40
 machine: "generic"
 arch: "x86_64"
-rpm_version: "4.0.9"
+rpm_version: "4.1.0"
 rpm_release: "0"
 installer_patch: ""
 ---


### PR DESCRIPTION
Our included rpm within the pre-build installers is now at our first stable release in the "Built on openSUSE" endeavour. Indicate this in our downloads page:

Fixes #32 

Includes:
- Re-ordering downloads so that the legacy CentOS version is last to be more consistend with our existing higher in list is better as a diy rpm install on openSUSE is still much preferred to the now years old CentOS based installer.
- Additional notes re the parity raid read-only default and hardware enhancement, both linking to our new how-to on stable kernel backport.
- Further enhancement to no use our CentOS variant via capitalisation.
- Minor re-wording.

Unrelated but timely:
- Update copyright year (we should have this automated if possible).