### PR TITLE
simplify and update 'About US' page intro - partial address of issue #36

### DIFF
--- a/content/about-us.md
+++ b/content/about-us.md
@@ -8,14 +8,12 @@ layout: about-us
 {{< center-this >}}
 The Rockstor Project, an open source community endeavour, is fostered by 2 discrete but co-operating entities:
 
-Rockstor, Inc. (US): run by project founder Suman Chakravartula - Domain and [trademarks]({{< ref legal.md >}}) owner/admin.
+*Rockstor, Inc. (US) owned by project founder Suman Chakravartula:- Domain and [trademarks]({{< ref legal.md >}}) owner/admin.*
 
-Sole trader (UK): Philip Paul Guyton - Current maintainer, project lead, packager, distributor, and subscription shop owner/admin.
+*Philip Paul Guyton:- Current maintainer, project lead, packager, distributor, and subscription shop owner/admin.*
 
-Shop/subscription proceeds, and donations, are backed by [Triodos](https://www.triodos.co.uk/) ethical & sustainable banking via a [Social Venture Current Account](https://www.triodos.co.uk/current-accounts/business-current-account).
-For distribution and our main website we use the "rockstor" domain.
-For support we use additionally the linuxlines/yewtreeapps domains.
-We hope to rationalise these 'mixed' domains as we work towards sustainable Open Source development.
+Our website uses the "rockstor" domain, while support uses the "linuxlines" domain.
+We hope to further rationalise these 'mixed' domains as we work towards sustainable Open Source development.
 
 ## Our Endeavour
 ---


### PR DESCRIPTION
Removes some older details relating to the current maintainer and shortens our otherwise overly wordy preamble.

Partially addresses issue #36 