### PR TITLE
Add link on downloads page to our v3 to v4 howto #44

### DIFF
--- a/content/dls/_index.md
+++ b/content/dls/_index.md
@@ -25,5 +25,7 @@ See our [Rockstor’s “Built on openSUSE” installer](/docs/installation/inst
 [Making a Rockstor USB install disk](/docs/installation/quickstart.html#making-a-rockstor-usb-install-disk)
 docs section.
 
+See also: [Migrating from Legacy V3 to V4 “Built on openSUSE”](/docs/howtos/v3_to_v4.html). 
+
 **Preferred options appear higher up in the following list.**
 {{< /center-this >}}


### PR DESCRIPTION
Add additional top-of-page text linking to our newly added HowTo on v3 to v4 migrations. This should ease the path for folks finding the new installer references and not realising a re-install import and config restore is required to make this jump.

Fixes #44