### PR TITLE
Add Release Candidate downloads #49

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -155,9 +155,9 @@ downloadsserver = "https://rockstor.com/"
 logo = "images/rockstorlogo-font2.png"
 author = "See: AUTHORS file."
 # Website copyright notice (markdownify)
-copyright = "Copyright &copy; 2022 Rockstor inc."
+copyright = "Copyright &copy; 2023 Rockstor inc."
 # use lowercase version of frontmatter os
-downloads_os_order = ["leap15.3", "diy", "rpm", "centos7.1511"]
+downloads_os_order = ["leap15.4", "leap15.3", "diy", "rpm", "centos7.1511"]
 
 # CSS Plugins
 [[params.plugins.css]]

--- a/content/dls/Leap15-3_ARM64EFI.md
+++ b/content/dls/Leap15-3_ARM64EFI.md
@@ -1,6 +1,6 @@
 ---
 title: "Leap15 3_ARM64EFI"
-date: 2021-10-19T17:21:01+01:00
+date: 2023-01-20T17:21:01+01:00
 draft: false
 icon: "fa fa-linux"
 download-base: "/"
@@ -8,10 +8,12 @@ os: "Leap15.3"
 os_weight: 50
 machine: "ARM64EFI"
 arch: "aarch64"
-rpm_version: "4.1.0"
+rpm_version: "4.5.5"
 rpm_release: "0"
 installer_patch: ""
 ---
+
+**NOTE: Leap 15.3 is end of life (EOL)**
 
 Awaiting Custom Ten64 drivers.
 Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)

--- a/content/dls/Leap15-3_RaspberryPi4.md
+++ b/content/dls/Leap15-3_RaspberryPi4.md
@@ -1,6 +1,6 @@
 ---
 title: "Leap15 3_RaspberryPi4"
-date: 2021-10-19T17:20:03+01:00
+date: 2023-01-20T17:20:03+01:00
 draft: false
 icon: "fa fa-linux"
 download-base: "/"
@@ -8,9 +8,11 @@ os: "Leap15.3"
 os_weight: 50
 machine: "RaspberryPi4"
 arch: "aarch64"
-rpm_version: "4.1.0"
+rpm_version: "4.5.5"
 rpm_release: "0"
 installer_patch: ""
 ---
+
+**NOTE: Leap 15.3 is end of life (EOL)**
 
 Also Pi 400 compatible.

--- a/content/dls/Leap15-4_ARM64EFI.md
+++ b/content/dls/Leap15-4_ARM64EFI.md
@@ -1,0 +1,23 @@
+---
+title: "Leap15 4_ARM64EFI"
+date: 2023-01-20T17:21:01+01:00
+draft: false
+icon: "fa fa-linux"
+download-base: "/"
+os: "Leap15.4"
+os_weight: 40
+machine: "ARM64EFI"
+arch: "aarch64"
+rpm_version: "4.5.5"
+rpm_release: "0"
+installer_patch: ""
+---
+
+[Stable Release Candidate status](https://forum.rockstor.com/t/v4-5-testing-channel-changelog/8546/6)
+
+**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+
+Awaiting Custom Ten64 drivers (may not be required any longer).
+Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
+to enable parity raid read-write access and for improved hardware compatibility.
+**NOTE: backports how-to needs modifying for 15.4**

--- a/content/dls/Leap15-4_RaspberryPi4.md
+++ b/content/dls/Leap15-4_RaspberryPi4.md
@@ -1,21 +1,24 @@
 ---
-title: "Leap15 3_x86_64"
-date: 2023-01-20T15:00:42+01:00
+title: "Leap15 4_RaspberryPi4"
+date: 2023-01-20T17:20:03+01:00
 draft: false
 icon: "fa fa-linux"
 download-base: "/"
-os: "Leap15.3"
-os_weight: 50
-machine: "generic"
-arch: "x86_64"
+os: "Leap15.4"
+os_weight: 40
+machine: "RaspberryPi4"
+arch: "aarch64"
 rpm_version: "4.5.5"
 rpm_release: "0"
 installer_patch: ""
 ---
 
-**NOTE: Leap 15.3 is end of life (EOL)**
+[Stable Release Candidate status](https://forum.rockstor.com/t/v4-5-testing-channel-changelog/8546/6)
 
 **Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
 
 Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
 to enable parity raid read-write access.
+**NOTE: backports how-to needs modifying for 15.4**
+
+***Also Pi 400 compatible***

--- a/content/dls/Leap15-4_x86_64.md
+++ b/content/dls/Leap15-4_x86_64.md
@@ -1,11 +1,11 @@
 ---
-title: "Leap15 3_x86_64"
+title: "Leap15 4_x86_64"
 date: 2023-01-20T15:00:42+01:00
 draft: false
 icon: "fa fa-linux"
 download-base: "/"
-os: "Leap15.3"
-os_weight: 50
+os: "Leap15.4"
+os_weight: 40
 machine: "generic"
 arch: "x86_64"
 rpm_version: "4.5.5"
@@ -13,9 +13,12 @@ rpm_release: "0"
 installer_patch: ""
 ---
 
-**NOTE: Leap 15.3 is end of life (EOL)**
+**Recommended**
+
+[Stable Release Candidate status](https://forum.rockstor.com/t/v4-5-testing-channel-changelog/8546/6)
 
 **Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
 
 Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
 to enable parity raid read-write access.
+**NOTE: backports how-to needs modifying for 15.4**

--- a/content/dls/_index.md
+++ b/content/dls/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Downloads"
-date: 2021-10-08T18:54:52+01:00
+date: 2023-01-20T18:54:52+01:00
 draft: false
 aliases:
     - /download.html
@@ -15,7 +15,9 @@ cascade:
 {{< center-this >}}
 ## Install using the options below.
 
-## "Built on openSUSE" installers use 1st v4 Stable release.
+## "Built on openSUSE" installers are Stable or RC* status.
+
+*Rockstor 4.5.5-0 = Next Stable Release Candidate (RC2)*
 
 *Rockstor 4.1.0-0 = First "Built on openSUSE" Stable Release*
 


### PR DESCRIPTION
Adds new set of 15.4 based installer download entries.

# Includes
- Updating existing 15.3 entries with EOL notice.
- Updating existing 15.3 entries to RC2 (4.5.5-0) based installers with all upstream updates pre-installed.
- Update site copyright year.

Fixes #49