### PR TITLE
Update "Built on openSUSE Rpm" to use RC* and Leap 15.4 #50

### DIFF
--- a/content/dls/rpm.md
+++ b/content/dls/rpm.md
@@ -8,7 +8,7 @@ os: "rpm"
 os_weight: 40
 machine: "generic"
 arch: "x86_64"
-rpm_version: "4.1.0"
+rpm_version: "4.5.8"
 rpm_release: "0"
 installer_patch: ""
 ---
@@ -18,7 +18,7 @@ Our installer profiles, and consequently our pre-build installers, deviate only 
 
 It is possible, **but not recommended or supported**, to add the relevant Rockstor repositories to a **dedicated** vanilla openSUSE / SuSE SLES non transactional server install.
 Assuming the base OS version is already found within our [Rockstor 4 Installer Recipe](https://github.com/rockstor/rockstor-installer).
-And in the case of SLES, is at least version 15.3 when the upstream binary compatibility between openSUSE Leap & SuSE SLES began.  
+And in the case of SLES, is at least version 15.4 when the upstream binary compatibility between openSUSE Leap & SuSE SLES matured.  
 
 ### **For advanced users only**
  
@@ -26,7 +26,7 @@ And in the case of SLES, is at least version 15.3 when the upstream binary compa
 It may also serve as an option where a SLES base is required.*
 **Please note our undesirable disabling of apparmor.** We hope to resolve this partial failure in due time.
 
-### Relevant commands (assuming a 15.3 base version):
+### Relevant commands (assuming a 15.4 base version):
 
 ---
 
@@ -40,21 +40,19 @@ systemctl enable NetworkManager
 
 systemctl start NetworkManager
 
-(**multiarch**) zypper \--non-interactive addrepo \--refresh -p105 https://download.opensuse.org/repositories/home:/rockstor/openSUSE_Leap_15.3/ home_rockstor
+(**multiarch**) zypper \--non-interactive addrepo \--refresh -p105 https://download.opensuse.org/repositories/home:/rockstor/15.4/ home_rockstor
 
-(**multiarch**) zypper \--non-interactive addrepo \--refresh -p97 https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.3/  home_rockstor_branches_Base_System
+(**multiarch**) zypper \--non-interactive addrepo \--refresh -p97 https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.4/  home_rockstor_branches_Base_System
 
 rpm \--import https://raw.githubusercontent.com/rockstor/rockstor-core/master/conf/ROCKSTOR-GPG-KEY
 
-(**x86_64 only**) zypper addrepo -f http://updates.rockstor.com:8999/rockstor-testing/leap/15.3/ Rockstor-Testing
-
-(**aarch64 only**) zypper addrepo -f http://updates.linuxlines.com:8999/rockstor-testing/leap/15.3_aarch64/ Rockstor-Testing
+(**multiarch**) zypper addrepo -f http://updates.rockstor.com:8999/rockstor-testing/leap/15.4/ Rockstor-Testing
 
 zypper \--non-interactive \--gpg-auto-import-keys refresh
 
 zypper in \--no-recommends rockstor-{{< param rpm_version >}}-{{< param rpm_release >}}
 
-systemctl start rockstor
+systemctl enable \--now rockstor-bootstrap
 
 **Please note that Rockstor is not yet Multi-path controller compatible.**
 


### PR DESCRIPTION
Modify this downloads DIY section to use 4.5.8-0 (RC5) and Leap 15.4 plus our newer multiarch repo and a better systemd command. Minor re-wording included.

Fixes #50 