### PR TITLE
Remove outdated backport howto warnings/links #64

### DIFF
--- a/content/dls/Leap15-3_ARM64EFI.md
+++ b/content/dls/Leap15-3_ARM64EFI.md
@@ -16,7 +16,3 @@ installer_patch: ""
 **NOTE: Leap 15.3 is end of life (EOL)**
 
 **Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
-
-Awaiting Custom Ten64 drivers.
-Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
-for improved hardware compatibility.

--- a/content/dls/Leap15-3_RaspberryPi4.md
+++ b/content/dls/Leap15-3_RaspberryPi4.md
@@ -17,4 +17,4 @@ installer_patch: ""
 
 **Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
 
-Also Pi 400 compatible.
+***Also Pi 400 compatible***

--- a/content/dls/Leap15-3_x86_64.md
+++ b/content/dls/Leap15-3_x86_64.md
@@ -17,5 +17,3 @@ installer_patch: ""
 
 **Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
 
-Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
-to enable parity raid read-write access.

--- a/content/dls/Leap15-4_ARM64EFI.md
+++ b/content/dls/Leap15-4_ARM64EFI.md
@@ -15,7 +15,5 @@ installer_patch: ""
 
 **Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
 
-Awaiting Custom Ten64 drivers (may not be required any longer).
 Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
-to enable parity raid read-write access and for improved hardware compatibility.
-**NOTE: backports how-to needs modifying for 15.4**
+to enable parity raid read-write access.

--- a/content/dls/Leap15-4_RaspberryPi4.md
+++ b/content/dls/Leap15-4_RaspberryPi4.md
@@ -17,6 +17,5 @@ installer_patch: ""
 
 Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
 to enable parity raid read-write access.
-**NOTE: backports how-to needs modifying for 15.4**
 
 ***Also Pi 400 compatible***

--- a/content/dls/Leap15-4_x86_64.md
+++ b/content/dls/Leap15-4_x86_64.md
@@ -19,4 +19,3 @@ installer_patch: ""
 
 Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
 to enable parity raid read-write access.
-**NOTE: backports how-to needs modifying for 15.4**


### PR DESCRIPTION
The referenced Howto is now 15.4 compatible so remove caveat text in all 15.4 downloads and remove all
reference to it in 15.3 as the url structure changes. Plus 15.3 is now EOL.

Includes removal of suspected legacy reference re Ten64. There were vagaries in the text we had to didn't help either way.

Fixes #64