### PR TITLE
Update Release Candidate downloads to 4.5.8-0 RC5 #66

### DIFF
--- a/content/dls/Leap15-3_ARM64EFI.md
+++ b/content/dls/Leap15-3_ARM64EFI.md
@@ -8,7 +8,7 @@ os: "Leap15.3"
 os_weight: 50
 machine: "ARM64EFI"
 arch: "aarch64"
-rpm_version: "4.5.6"
+rpm_version: "4.5.8"
 rpm_release: "0"
 installer_patch: ""
 ---
@@ -16,3 +16,5 @@ installer_patch: ""
 **NOTE: Leap 15.3 is end of life (EOL)**
 
 **Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+
+[Fresh install Failure with Work-around](https://github.com/rockstor/rockstor-core/issues/2516)

--- a/content/dls/Leap15-3_RaspberryPi4.md
+++ b/content/dls/Leap15-3_RaspberryPi4.md
@@ -8,7 +8,7 @@ os: "Leap15.3"
 os_weight: 50
 machine: "RaspberryPi4"
 arch: "aarch64"
-rpm_version: "4.5.6"
+rpm_version: "4.5.8"
 rpm_release: "0"
 installer_patch: ""
 ---
@@ -18,3 +18,5 @@ installer_patch: ""
 **Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
 
 ***Also Pi 400 compatible***
+
+[Fresh install Failure with Work-around](https://github.com/rockstor/rockstor-core/issues/2516)

--- a/content/dls/Leap15-3_x86_64.md
+++ b/content/dls/Leap15-3_x86_64.md
@@ -8,7 +8,7 @@ os: "Leap15.3"
 os_weight: 50
 machine: "generic"
 arch: "x86_64"
-rpm_version: "4.5.6"
+rpm_version: "4.5.8"
 rpm_release: "0"
 installer_patch: ""
 ---
@@ -17,3 +17,4 @@ installer_patch: ""
 
 **Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
 
+[Fresh install Failure with Work-around](https://github.com/rockstor/rockstor-core/issues/2516)

--- a/content/dls/Leap15-4_ARM64EFI.md
+++ b/content/dls/Leap15-4_ARM64EFI.md
@@ -8,7 +8,7 @@ os: "Leap15.4"
 os_weight: 40
 machine: "ARM64EFI"
 arch: "aarch64"
-rpm_version: "4.5.6"
+rpm_version: "4.5.8"
 rpm_release: "0"
 installer_patch: ""
 ---

--- a/content/dls/Leap15-4_RaspberryPi4.md
+++ b/content/dls/Leap15-4_RaspberryPi4.md
@@ -8,7 +8,7 @@ os: "Leap15.4"
 os_weight: 40
 machine: "RaspberryPi4"
 arch: "aarch64"
-rpm_version: "4.5.6"
+rpm_version: "4.5.8"
 rpm_release: "0"
 installer_patch: ""
 ---

--- a/content/dls/Leap15-4_x86_64.md
+++ b/content/dls/Leap15-4_x86_64.md
@@ -8,7 +8,7 @@ os: "Leap15.4"
 os_weight: 40
 machine: "generic"
 arch: "x86_64"
-rpm_version: "4.5.6"
+rpm_version: "4.5.8"
 rpm_release: "0"
 installer_patch: ""
 ---

--- a/content/dls/_index.md
+++ b/content/dls/_index.md
@@ -17,7 +17,7 @@ cascade:
 
 ## "Built on openSUSE" installers are Stable or RC* status.
 
-*Rockstor 4.5.6-0 = Next Stable Release Candidate (RC3)*
+***Rockstor 4.5.8-0 = Stable Release Candidate (RC5)***
 
 [Stable Release Candidate status](https://forum.rockstor.com/t/v4-5-testing-channel-changelog/8546/7) **---**
 [GitHub Milestone](https://github.com/rockstor/rockstor-core/milestone/19)

--- a/content/dls/_index.md
+++ b/content/dls/_index.md
@@ -19,7 +19,7 @@ cascade:
 
 ***Rockstor 4.5.8-0 = Stable Release Candidate (RC5)***
 
-[Stable Release Candidate status](https://forum.rockstor.com/t/v4-5-testing-channel-changelog/8546/7) **---**
+[Stable Release Candidate status](https://forum.rockstor.com/t/v4-5-testing-channel-changelog/8546/10) **---**
 [GitHub Milestone](https://github.com/rockstor/rockstor-core/milestone/19)
 
 *Rockstor 4.1.0-0 = First "Built on openSUSE" Stable Release*


### PR DESCRIPTION
We have recently updated to Stable Release Candidate 5 within our testing channel, and rebuilt 15.3 & 15.4 downloadable installers to include this new version. Update the downloads page accordingly.

Add note to EOL 15.3 based installers re a known
failure with workaround, detailed via a link to the relevant GitHub issue.

Fixes #66 

Merge and publish awaiting uploads.