### PR TITLE
Add Dev/Advanced-user/Rescue Tumbleweed download section #70

### DIFF
--- a/archetypes/dls.md
+++ b/archetypes/dls.md
@@ -4,11 +4,11 @@ date: {{ .Date }}
 draft: true
 icon: "fa-brands fa-linux"
 download-base: "/"
-os: "Leap15.2|Leap15.3"
+os: "Leap15.3|Leap15.4|Tumbleweed"
 os_weight: 40
 machine: "generic|RaspberryPi4|ARM64EFI"
 arch: "x86_64|aarch64"
-rpm_version: "4.0.9"
+rpm_version: "4.5.8"
 rpm_release: "0"
 installer_patch: ""
 ---

--- a/config.toml
+++ b/config.toml
@@ -157,7 +157,7 @@ author = "See: AUTHORS file."
 # Website copyright notice (markdownify)
 copyright = "Copyright &copy; 2023 Rockstor inc."
 # use lowercase version of frontmatter os
-downloads_os_order = ["leap15.4", "leap15.3", "diy", "rpm", "centos7.1511"]
+downloads_os_order = ["leap15.4", "tumbleweed", "leap15.3", "diy", "rpm", "centos7.1511"]
 
 # CSS Plugins
 [[params.plugins.css]]

--- a/content/dls/Leap15-3_ARM64EFI.md
+++ b/content/dls/Leap15-3_ARM64EFI.md
@@ -5,7 +5,7 @@ draft: false
 icon: "fa-brands fa-linux"
 download-base: "/"
 os: "Leap15.3"
-os_weight: 50
+os_weight: 52
 machine: "ARM64EFI"
 arch: "aarch64"
 rpm_version: "4.5.8"

--- a/content/dls/Leap15-3_RaspberryPi4.md
+++ b/content/dls/Leap15-3_RaspberryPi4.md
@@ -5,7 +5,7 @@ draft: false
 icon: "fa-brands fa-linux"
 download-base: "/"
 os: "Leap15.3"
-os_weight: 50
+os_weight: 51
 machine: "RaspberryPi4"
 arch: "aarch64"
 rpm_version: "4.5.8"

--- a/content/dls/Leap15-4_ARM64EFI.md
+++ b/content/dls/Leap15-4_ARM64EFI.md
@@ -5,7 +5,7 @@ draft: false
 icon: "fa-brands fa-linux"
 download-base: "/"
 os: "Leap15.4"
-os_weight: 40
+os_weight: 42
 machine: "ARM64EFI"
 arch: "aarch64"
 rpm_version: "4.5.8"

--- a/content/dls/Leap15-4_RaspberryPi4.md
+++ b/content/dls/Leap15-4_RaspberryPi4.md
@@ -5,7 +5,7 @@ draft: false
 icon: "fa-brands fa-linux"
 download-base: "/"
 os: "Leap15.4"
-os_weight: 40
+os_weight: 41
 machine: "RaspberryPi4"
 arch: "aarch64"
 rpm_version: "4.5.8"

--- a/content/dls/Tumbleweed_ARM64EFI.md
+++ b/content/dls/Tumbleweed_ARM64EFI.md
@@ -15,4 +15,4 @@ installer_patch: ""
 
 ***Development/Advanced-user/Rescue use only***
 
-[initial zypper dup requried](https://github.com/rockstor/rockstor-website/issues/71)
+[initial zypper dup required](https://github.com/rockstor/rockstor-website/issues/71)

--- a/content/dls/Tumbleweed_ARM64EFI.md
+++ b/content/dls/Tumbleweed_ARM64EFI.md
@@ -1,0 +1,18 @@
+---
+title: "Tumbleweed_ARM64EFI"
+date: 2023-03-18T16:45:48Z
+draft: true
+icon: "fa-brands fa-linux"
+download-base: "/"
+os: "Tumbleweed"
+os_weight: 42
+machine: "ARM64EFI"
+arch: "aarch64"
+rpm_version: "4.5.8"
+rpm_release: "0"
+installer_patch: ""
+---
+
+***Development/Advanced-user/Rescue use only***
+
+[initial zypper dup requried](https://github.com/rockstor/rockstor-website/issues/71)

--- a/content/dls/Tumbleweed_ARM64EFI.md
+++ b/content/dls/Tumbleweed_ARM64EFI.md
@@ -1,7 +1,7 @@
 ---
 title: "Tumbleweed_ARM64EFI"
 date: 2023-03-18T16:45:48Z
-draft: true
+draft: false
 icon: "fa-brands fa-linux"
 download-base: "/"
 os: "Tumbleweed"

--- a/content/dls/Tumbleweed_RaspberryPi4.md
+++ b/content/dls/Tumbleweed_RaspberryPi4.md
@@ -15,4 +15,4 @@ installer_patch: ""
 
 ***Development/Advanced-user/Rescue use only***
 
-[initial zypper dup requried](https://github.com/rockstor/rockstor-website/issues/71)
+[initial zypper dup required](https://github.com/rockstor/rockstor-website/issues/71)

--- a/content/dls/Tumbleweed_RaspberryPi4.md
+++ b/content/dls/Tumbleweed_RaspberryPi4.md
@@ -1,0 +1,18 @@
+---
+title: "Tumbleweed_RaspberryPi4"
+date: 2023-03-18T16:46:10Z
+draft: true
+icon: "fa-brands fa-linux"
+download-base: "/"
+os: "Tumbleweed"
+os_weight: 41
+machine: "RaspberryPi4"
+arch: "aarch64"
+rpm_version: "4.5.8"
+rpm_release: "0"
+installer_patch: ""
+---
+
+***Development/Advanced-user/Rescue use only***
+
+[initial zypper dup requried](https://github.com/rockstor/rockstor-website/issues/71)

--- a/content/dls/Tumbleweed_RaspberryPi4.md
+++ b/content/dls/Tumbleweed_RaspberryPi4.md
@@ -1,7 +1,7 @@
 ---
 title: "Tumbleweed_RaspberryPi4"
 date: 2023-03-18T16:46:10Z
-draft: true
+draft: false
 icon: "fa-brands fa-linux"
 download-base: "/"
 os: "Tumbleweed"

--- a/content/dls/Tumbleweed_x86_64.md
+++ b/content/dls/Tumbleweed_x86_64.md
@@ -15,4 +15,4 @@ installer_patch: ""
 
 ***Development/Advanced-user/Rescue use only***
 
-[initial zypper dup requried](https://github.com/rockstor/rockstor-website/issues/71)
+[initial zypper dup required](https://github.com/rockstor/rockstor-website/issues/71)

--- a/content/dls/Tumbleweed_x86_64.md
+++ b/content/dls/Tumbleweed_x86_64.md
@@ -1,7 +1,7 @@
 ---
 title: "Tumbleweed_x86_64"
 date: 2023-03-18T16:45:05Z
-draft: true
+draft: false
 icon: "fa-brands fa-linux"
 download-base: "/"
 os: "Tumbleweed"

--- a/content/dls/Tumbleweed_x86_64.md
+++ b/content/dls/Tumbleweed_x86_64.md
@@ -1,0 +1,18 @@
+---
+title: "Tumbleweed_x86_64"
+date: 2023-03-18T16:45:05Z
+draft: true
+icon: "fa-brands fa-linux"
+download-base: "/"
+os: "Tumbleweed"
+os_weight: 40
+machine: "generic"
+arch: "x86_64"
+rpm_version: "4.5.8"
+rpm_release: "0"
+installer_patch: ""
+---
+
+***Development/Advanced-user/Rescue use only***
+
+[initial zypper dup requried](https://github.com/rockstor/rockstor-website/issues/71)

--- a/content/dls/rpm.md
+++ b/content/dls/rpm.md
@@ -13,50 +13,10 @@ rpm_release: "0"
 installer_patch: ""
 ---
 
+For the advanced rpm only install method 
 
-Our installer profiles, and consequently our pre-build installers, deviate only a little from openSUSE's JeOS appliance profiles.
+***See our [Install on Vanilla openSUSE/SuSE SLES](https://rockstor.com/docs/howtos/rpm_install.html) How-to.***
 
-It is possible, **but not recommended or supported**, to add the relevant Rockstor repositories to a **dedicated** vanilla openSUSE / SuSE SLES non transactional server install.
-Assuming the base OS version is already found within our [Rockstor 4 Installer Recipe](https://github.com/rockstor/rockstor-installer).
-And in the case of SLES, is at least version 15.4 when the upstream binary compatibility between openSUSE Leap & SuSE SLES matured.  
-
-### **For advanced users only**
- 
-*This install method is predominantly for developers or advanced users and will likely require additional maintenance.
-It may also serve as an option where a SLES base is required.*
-**Please note our undesirable disabling of apparmor.** We hope to resolve this partial failure in due time.
-
-### Relevant commands (assuming a 15.4 base version):
-
----
-
-systemctl disable apparmor
-
-zypper install \--no-recommends NetworkManager
-
-systemctl disable wicked
-
-systemctl enable NetworkManager
-
-systemctl start NetworkManager
-
-(**multiarch**) zypper \--non-interactive addrepo \--refresh -p105 https://download.opensuse.org/repositories/home:/rockstor/15.4/ home_rockstor
-
-(**multiarch**) zypper \--non-interactive addrepo \--refresh -p97 https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.4/  home_rockstor_branches_Base_System
-
-rpm \--import https://raw.githubusercontent.com/rockstor/rockstor-core/master/conf/ROCKSTOR-GPG-KEY
-
-(**multiarch**) zypper addrepo -f http://updates.rockstor.com:8999/rockstor-testing/leap/15.4/ Rockstor-Testing
-
-zypper \--non-interactive \--gpg-auto-import-keys refresh
-
-zypper in \--no-recommends rockstor-{{< param rpm_version >}}-{{< param rpm_release >}}
-
-systemctl enable \--now rockstor-bootstrap
-
-**Please note that Rockstor is not yet Multi-path controller compatible.**
-
-**As always GitHub Pull Requests are Welcome.**
 
 
 


### PR DESCRIPTION
Fixes #70 

# Includes
- Determining intra base OS list order to be: Generic (x86_64), Pi4, ARM64EFI
this order was previously random.
- Asset Tumbleweed base as preferred over EOL 15.3.
- Removal of now replicated in docs rpm install method instructions. Link to new howto provided
instead.
- Update downloads archetypes.