### PR TITLE
Normalise on rockstor.com for support email #75

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -185,7 +185,7 @@ link = "js/bootstrap.min.js"
 # text is markdown
 [[params.email]]
 icon = "fa-solid fa-envelope fa-xl"
-link = "mailto:support@linuxlines.com"
+link = "mailto:support@rockstor.com"
 label = "Support Email"
 text = "Email for support, questions, or advice."
 

--- a/content/about-us.md
+++ b/content/about-us.md
@@ -15,8 +15,8 @@ We are supported by our members/subscribers/contributors and fiscally hosted by 
 
 *Current Maintainer: Philip Paul Guyton - Project lead, core developer, & release manager.*
 
-Our website uses the "rockstor" domain, while support uses the "linuxlines" domain.
-We hope to further rationalise these 'mixed' domains as we work towards sustainable Open Source development.
+Our websites & support email use the "rockstor" domain. But forum notifications uses the "linuxlines" domain.
+This mixed domain use should be resolved soon.
 
 ## Our Endeavour
 ---
@@ -53,7 +53,7 @@ Repository |           About           | Contributors
 [rockstor-website](https://github.com/rockstor/rockstor-website) |    This WebSite (Hugo)    | [6](https://github.com/rockstor/rockstor-website/blob/master/AUTHORS)
 
 {{< /bootstrap-table >}}
-*(Contibutors: git shortlog -sn --all | wc -l)*
+*(Contributors: git shortlog -sn --all | wc -l)*
 
 ## Contact Us
 ---


### PR DESCRIPTION
Our Web-UI and GitHub Org (as of just recently) are now using the more 'proper' support@rockstor.com.
Make this the case also for our main Website.

Fixes #75 

Includes:
- an about-us.md update re mixed domain use.
- Unrelated prior 'Contibutors' spelling typo.