### PR TITLE
Switch 'Shop' in header for "Open Collective" #79

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -132,8 +132,8 @@ pageRef = "about-us.md"
 weight = 4
 
 [[menu.main]]
-name = "Shop"
-url = "https://shop.rockstor.com/"
+name = "Open Collective"
+url = "https://opencollective.com/the-rockstor-project"
 weight = 5
 
 [[menu.main]]

--- a/content/about-us.md
+++ b/content/about-us.md
@@ -11,7 +11,7 @@ is an [Open Collective](https://opencollective.com/) Non-Profit/Non-Business Ope
 
 We are supported by our members/subscribers/contributors and fiscally hosted by [Open Collective Europe](https://opencollective.com/europe).
 
-*Founder & prior Maintainer: Suman Chakravartula - Domain and [trademarks]({{< ref legal.md >}}) owner/admin.*
+*Founder & prior Maintainer: Suman Chakravartula - Domain and [trademarks]({{< relref legal.md >}}) owner/admin.*
 
 *Current Maintainer: Philip Paul Guyton - Project lead, core developer, & release manager.*
 

--- a/content/commercial_support.md
+++ b/content/commercial_support.md
@@ -14,7 +14,7 @@ draft: false
 
 #### Apologies for any inconvenience.
 
-##### Our [downloadable]({{< ref dls.md >}}) installers are Stable or Release Candidate status.
+##### Our [downloadable]({{< relref dls.md >}}) installers are Stable or Release Candidate status.
 
 ---
 

--- a/content/dls/diy.md
+++ b/content/dls/diy.md
@@ -18,7 +18,7 @@ This in-turn uses the excellent [Kiwi-ng](https://github.com/OSInside/kiwi) open
 See [Kiwi-ng's docs](https://osinside.github.io/kiwi/) for the possibilities.
 
 You can also create your own custom profile tailored to your specific needs.
-Please see our [Custom Solutions]({{< ref customizable-btrfs-nas-storage-platform.md >}}) for context.
+Please see our [Custom Solutions]({{< relref customizable-btrfs-nas-storage-platform.md >}}) for context.
 
 All pending upstream updates, at time of installer build/re-build, are pre-applied to the resulting image.
 

--- a/content/features/_index.md
+++ b/content/features/_index.md
@@ -11,4 +11,4 @@ Rockstor is a Linux and BTRFS powered storage operating system with advanced NAS
 Compatible with commodity hardware - managed with ease via browser.
 For Small to Mid-size organizations looking for **Anti-Bitrot** flexible storage.
 
-**Click icons** for Documentation. or use [Browse view]({{< ref file-sharing.md >}})
+**Click icons** for Documentation. or use [Browse view]({{< relref file-sharing.md >}})

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,5 @@
+<!-- https://gohugo.io/templates/render-hooks/  -->
+<!-- affects md content links only -->
+<a href="{{ .Destination | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"
+rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>
+

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -19,14 +19,15 @@
                aria-expanded="false"> {{ .Name }} </a>
             <ul class="dropdown-menu">
               {{ range .Children }}
-              <li><a class="dropdown-item" href="{{ .URL | absLangURL }}">{{ .Name }}</a></li>
+              <li><a class="dropdown-item" href="{{ .URL | absLangURL }}" {{ if strings.HasPrefix .URL "http" }} target="_blank"
+                rel="noopener"{{ end }}>{{ .Name }}</a></li>
               {{ end }}
             </ul>
           </li>
 
           {{ else }}
           <li class="nav-item">
-            <a class="nav-link text-uppercase text-dark" href="{{ .URL | absLangURL }}">{{ .Name }}</a>
+            <a class="nav-link text-uppercase text-dark" href="{{ .URL | absLangURL }}" {{ if eq .Name "Open Collective"}} target="_blank" rel="noopener"{{end}} >{{ .Name }}</a>
           </li>
           {{ end }}
 


### PR DESCRIPTION
Includes move to relref in contend md and adoption of newer Hugo md renderer Goldmark's render hook:
render-link.html - to enable external link opening with target="_blank" (in a new tab). A similar filter was used to do the same for menu items via header.html additions.

Fixes #79 