### PR TITLE
Setup legacy shop.rockstor.com landing page #85

### DIFF
--- a/content/legacy-shop-info.md
+++ b/content/legacy-shop-info.md
@@ -1,0 +1,32 @@
+---
+title: "Legacy Shop Info"
+date: 2024-01-11T15:46:42Z
+draft: false
+---
+{{< center-this >}}
+You are likely viewing this page via an outdated email or Rockstor Web-UI.
+
+We no longer use **shop.rockstor.com**.
+
+[The Rockstor Project](https://opencollective.com/the-rockstor-project)
+is now an [Open Collective](https://opencollective.com/) Non-Profit/Non-Business.
+
+---
+
+To Activate Stable updates.
+
+Please follow these *updated* steps.
+
+**Steps 1 & 2 will each send confirmation / information emails.**
+
+1:- Become a "Stable Updates subscription" contributor / member at our [Open Collective](https://opencollective.com/the-rockstor-project/contribute).
+
+2:- Enter / Edit / Check your Current Appliance ID in your [Appliance ID manager](https://appman.rockstor.com/) **Appman**.
+
+3:- Enter your Activation code, emailed by Appman immediately after step 2.
+
+---
+
+Thank you for helping to support Rockstor's development.
+
+{{< /center-this >}}


### PR DESCRIPTION
Initial updated instructions, in dedicated page, for those with outdated systems that still have a link to shop.rockstor.com in the menu, and within the stable updates activation interface.

Closes #85 