### PR TITLE
Update downloads re EOL 15.3 - 15.4 - and add 15.5 #87

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -157,7 +157,7 @@ author = "See: AUTHORS file."
 # Website copyright notice (markdownify)
 copyright = "Copyright &copy; 2023 Rockstor inc."
 # use lowercase version of frontmatter os
-downloads_os_order = ["leap15.4", "tumbleweed", "leap15.3", "diy", "rpm", "centos7.1511"]
+downloads_os_order = ["leap15.5", "tumbleweed", "diy", "rpm", "centos7.1511"]
 
 # CSS Plugins
 [[params.plugins.css]]

--- a/content/dls/Leap15-5_ARM64EFI.md
+++ b/content/dls/Leap15-5_ARM64EFI.md
@@ -1,0 +1,19 @@
+---
+title: "Leap15 5_ARM64EFI"
+date: 2023-01-26T17:21:01+01:00
+draft: false
+icon: "fa-brands fa-linux"
+download-base: "/"
+os: "Leap15.5"
+os_weight: 42
+machine: "ARM64EFI"
+arch: "aarch64"
+rpm_version: "5.0.6"
+rpm_release: "0"
+installer_patch: ""
+---
+
+**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+
+Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
+to enable parity raid read-write access.

--- a/content/dls/Leap15-5_RaspberryPi4.md
+++ b/content/dls/Leap15-5_RaspberryPi4.md
@@ -1,0 +1,21 @@
+---
+title: "Leap15 5_RaspberryPi4"
+date: 2023-01-26T17:20:03+01:00
+draft: false
+icon: "fa-brands fa-linux"
+download-base: "/"
+os: "Leap15.5"
+os_weight: 41
+machine: "RaspberryPi4"
+arch: "aarch64"
+rpm_version: "5.0.6"
+rpm_release: "0"
+installer_patch: ""
+---
+
+**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+
+Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
+to enable parity raid read-write access.
+
+***Also Pi 400 compatible***

--- a/content/dls/Leap15-5_x86_64.md
+++ b/content/dls/Leap15-5_x86_64.md
@@ -1,0 +1,21 @@
+---
+title: "Leap15 5_x86_64"
+date: 2023-01-26T15:00:42+01:00
+draft: false
+icon: "fa-brands fa-linux"
+download-base: "/"
+os: "Leap15.5"
+os_weight: 40
+machine: "generic"
+arch: "x86_64"
+rpm_version: "5.0.6"
+rpm_release: "0"
+installer_patch: ""
+---
+
+**Recommended**
+
+**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+
+Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
+to enable parity raid read-write access.

--- a/content/dls/Tumbleweed_ARM64EFI.md
+++ b/content/dls/Tumbleweed_ARM64EFI.md
@@ -8,7 +8,7 @@ os: "Tumbleweed"
 os_weight: 42
 machine: "ARM64EFI"
 arch: "aarch64"
-rpm_version: "4.5.8"
+rpm_version: "5.0.6"
 rpm_release: "0"
 installer_patch: ""
 ---

--- a/content/dls/Tumbleweed_RaspberryPi4.md
+++ b/content/dls/Tumbleweed_RaspberryPi4.md
@@ -8,7 +8,7 @@ os: "Tumbleweed"
 os_weight: 41
 machine: "RaspberryPi4"
 arch: "aarch64"
-rpm_version: "4.5.8"
+rpm_version: "5.0.6"
 rpm_release: "0"
 installer_patch: ""
 ---

--- a/content/dls/Tumbleweed_x86_64.md
+++ b/content/dls/Tumbleweed_x86_64.md
@@ -8,7 +8,7 @@ os: "Tumbleweed"
 os_weight: 40
 machine: "generic"
 arch: "x86_64"
-rpm_version: "4.5.8"
+rpm_version: "5.0.6"
 rpm_release: "0"
 installer_patch: ""
 ---

--- a/content/dls/_index.md
+++ b/content/dls/_index.md
@@ -17,14 +17,18 @@ cascade:
 
 ## "Built on openSUSE" installers are Stable or RC* status.
 
-***Rockstor 4.5.8-0 = Stable Release Candidate (RC5)***
+***Rockstor 5.0.6-0 = Stable Release Candidate (RC1)***
 
-[Stable Release Candidate status](https://forum.rockstor.com/t/v4-5-testing-channel-changelog/8546/10) **---**
-[GitHub Milestone](https://github.com/rockstor/rockstor-core/milestone/19)
+[Stable Release Candidate status](https://forum.rockstor.com/t/v5-0-testing-channel-changelog/8898/12) **---**
+[GitHub Milestone](https://github.com/rockstor/rockstor-core/milestone/27)
 
-*Rockstor 4.1.0-0 = First "Built on openSUSE" Stable Release*
+*4.1.0-0 was our first "Built on openSUSE" Stable Release*
 
-*Rockstor 4 is now also Pi4 & ARM64 [Embedded Boot](https://github.com/ARM-software/ebbr) / [Server Boot](https://github.com/ARM-software/sbsa-acs) compatible.*
+*4.6.0-0 was our "First Stable Poetry build" - with a 4.6.1-0 hot-patch*
+
+---
+
+*We are now Pi4 & ARM64 [Embedded Boot](https://github.com/ARM-software/ebbr) / [Server Boot](https://github.com/ARM-software/sbsa-acs) compatible.*
 
 See our [Rockstor’s “Built on openSUSE” installer](/docs/installation/installer-howto.html) and 
 [Making a Rockstor USB install disk](/docs/installation/quickstart.html#making-a-rockstor-usb-install-disk)


### PR DESCRIPTION
Remove EOL Leap entries and add 15.5 and TW installers based on current Stable RC releases in current testing phase.

Fixes #87 

Currently depends on a fix/new-release associated with:

- [X]  "5.0.6-0 rpm posttrans scriptlet failure": https://github.com/rockstor/rockstor-installer/issues/155
Fixed by rockstor-core PR: https://github.com/rockstor/rockstor-core/pull/2795
And partnered rockstor-rpmbuild PR: https://github.com/rockstor/rockstor-rpmbuild/pull/63