### PR TITLE
Update downloads re EOL 15.3 - 15.4 - and add 15.5 - 15.6 #87

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -157,7 +157,7 @@ author = "See: AUTHORS file."
 # Website copyright notice (markdownify)
 copyright = "Copyright &copy; 2024 The Rockstor Project"
 # use lowercase version of frontmatter os
-downloads_os_order = ["leap15.4", "tumbleweed", "leap15.3", "diy", "rpm", "centos7.1511"]
+downloads_os_order = ["leap15.5", "leap15.6", "tumbleweed", "diy", "rpm", "centos7.1511"]
 
 # CSS Plugins
 [[params.plugins.css]]

--- a/config.toml
+++ b/config.toml
@@ -157,7 +157,7 @@ author = "See: AUTHORS file."
 # Website copyright notice (markdownify)
 copyright = "Copyright &copy; 2024 The Rockstor Project"
 # use lowercase version of frontmatter os
-downloads_os_order = ["leap15.5", "leap15.6", "tumbleweed", "diy", "rpm", "centos7.1511"]
+downloads_os_order = ["leap15.6", "leap15.5", "tumbleweed", "diy", "rpm", "centos7.1511"]
 
 # CSS Plugins
 [[params.plugins.css]]

--- a/content/dls/Leap15-5_ARM64EFI.md
+++ b/content/dls/Leap15-5_ARM64EFI.md
@@ -1,0 +1,19 @@
+---
+title: "Leap15 5_ARM64EFI"
+date: 2023-01-26T17:21:01+01:00
+draft: false
+icon: "fa-brands fa-linux"
+download-base: "/"
+os: "Leap15.5"
+os_weight: 42
+machine: "ARM64EFI"
+arch: "aarch64"
+rpm_version: "5.0.9"
+rpm_release: "0"
+installer_patch: ""
+---
+
+**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+
+Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
+to enable parity raid read-write access.

--- a/content/dls/Leap15-5_RaspberryPi4.md
+++ b/content/dls/Leap15-5_RaspberryPi4.md
@@ -13,9 +13,11 @@ rpm_release: "0"
 installer_patch: ""
 ---
 
+--- **REBOOT BUG:** [Pi4 installer fails on reboot](https://github.com/rockstor/rockstor-core/issues/2843) ---
+
 **Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
 
 Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
 to enable parity raid read-write access.
 
-***Also Pi 400 compatible***
+*Also Pi 400 compatible*

--- a/content/dls/Leap15-5_RaspberryPi4.md
+++ b/content/dls/Leap15-5_RaspberryPi4.md
@@ -1,0 +1,21 @@
+---
+title: "Leap15 5_RaspberryPi4"
+date: 2023-01-26T17:20:03+01:00
+draft: false
+icon: "fa-brands fa-linux"
+download-base: "/"
+os: "Leap15.5"
+os_weight: 41
+machine: "RaspberryPi4"
+arch: "aarch64"
+rpm_version: "5.0.9"
+rpm_release: "0"
+installer_patch: ""
+---
+
+**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+
+Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
+to enable parity raid read-write access.
+
+***Also Pi 400 compatible***

--- a/content/dls/Leap15-5_x86_64.md
+++ b/content/dls/Leap15-5_x86_64.md
@@ -13,8 +13,6 @@ rpm_release: "0"
 installer_patch: ""
 ---
 
-**Recommended**
-
 **Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
 
 Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)

--- a/content/dls/Leap15-5_x86_64.md
+++ b/content/dls/Leap15-5_x86_64.md
@@ -1,0 +1,21 @@
+---
+title: "Leap15 5_x86_64"
+date: 2023-01-26T15:00:42+01:00
+draft: false
+icon: "fa-brands fa-linux"
+download-base: "/"
+os: "Leap15.5"
+os_weight: 40
+machine: "generic"
+arch: "x86_64"
+rpm_version: "5.0.9"
+rpm_release: "0"
+installer_patch: ""
+---
+
+**Recommended**
+
+**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+
+Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
+to enable parity raid read-write access.

--- a/content/dls/Leap15-6_ARM64EFI.md
+++ b/content/dls/Leap15-6_ARM64EFI.md
@@ -12,9 +12,5 @@ rpm_version: "5.0.9"
 rpm_release: "0"
 installer_patch: ""
 ---
-**WARNING: Build using pre-release Leap 15.6** *- will require 'zypper dup' post 15.6 release -*
 
-**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
-
-Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
-to enable parity raid read-write access.
+**WARNING: Built using pre-release Leap 15.6** *- will require 'zypper dup' post 15.6 release -*

--- a/content/dls/Leap15-6_ARM64EFI.md
+++ b/content/dls/Leap15-6_ARM64EFI.md
@@ -1,0 +1,20 @@
+---
+title: "Leap15 6_ARM64EFI"
+date: 2023-01-26T17:21:01+01:00
+draft: false
+icon: "fa-brands fa-linux"
+download-base: "/"
+os: "Leap15.6"
+os_weight: 42
+machine: "ARM64EFI"
+arch: "aarch64"
+rpm_version: "5.0.9"
+rpm_release: "0"
+installer_patch: ""
+---
+**WARNING: Build using pre-release Leap 15.6** *- will require 'zypper dup' post 15.6 release -*
+
+**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+
+Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
+to enable parity raid read-write access.

--- a/content/dls/Leap15-6_RaspberryPi4.md
+++ b/content/dls/Leap15-6_RaspberryPi4.md
@@ -12,11 +12,9 @@ rpm_version: "5.0.9"
 rpm_release: "0"
 installer_patch: ""
 ---
-**WARNING: Build using pre-release Leap 15.6** *- will require 'zypper dup' post 15.6 release -*
 
-**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+--- **REBOOT BUG:** [Pi4 installer fails on reboot](https://github.com/rockstor/rockstor-core/issues/2843) ---
 
-Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
-to enable parity raid read-write access.
+**WARNING: Built using pre-release Leap 15.6** *- will require 'zypper dup' post 15.6 release -*
 
-***Also Pi 400 compatible***
+*Also Pi 400 compatible*

--- a/content/dls/Leap15-6_RaspberryPi4.md
+++ b/content/dls/Leap15-6_RaspberryPi4.md
@@ -1,0 +1,22 @@
+---
+title: "Leap15 6_RaspberryPi4"
+date: 2023-01-26T17:20:03+01:00
+draft: false
+icon: "fa-brands fa-linux"
+download-base: "/"
+os: "Leap15.6"
+os_weight: 41
+machine: "RaspberryPi4"
+arch: "aarch64"
+rpm_version: "5.0.9"
+rpm_release: "0"
+installer_patch: ""
+---
+**WARNING: Build using pre-release Leap 15.6** *- will require 'zypper dup' post 15.6 release -*
+
+**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+
+Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
+to enable parity raid read-write access.
+
+***Also Pi 400 compatible***

--- a/content/dls/Leap15-6_x86_64.md
+++ b/content/dls/Leap15-6_x86_64.md
@@ -1,0 +1,20 @@
+---
+title: "Leap15 6_x86_64"
+date: 2023-01-26T15:00:42+01:00
+draft: false
+icon: "fa-brands fa-linux"
+download-base: "/"
+os: "Leap15.6"
+os_weight: 40
+machine: "generic"
+arch: "x86_64"
+rpm_version: "5.0.9"
+rpm_release: "0"
+installer_patch: ""
+---
+**WARNING: Build using pre-release Leap 15.6** *- will require 'zypper dup' post 15.6 release -*
+
+**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+
+Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
+to enable parity raid read-write access.

--- a/content/dls/Leap15-6_x86_64.md
+++ b/content/dls/Leap15-6_x86_64.md
@@ -12,9 +12,8 @@ rpm_version: "5.0.9"
 rpm_release: "0"
 installer_patch: ""
 ---
-**WARNING: Build using pre-release Leap 15.6** *- will require 'zypper dup' post 15.6 release -*
 
-**Note:** *Btrfs parity raid levels (5&6) are read-only by default.*
+**Recommended**
 
-Consider our [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html)
-to enable parity raid read-write access.
+**WARNING: Built using pre-release Leap 15.6** *- will require 'zypper dup' post 15.6 release -*
+

--- a/content/dls/Tumbleweed_ARM64EFI.md
+++ b/content/dls/Tumbleweed_ARM64EFI.md
@@ -14,5 +14,3 @@ installer_patch: ""
 ---
 
 ***Development/Advanced-user/Rescue use only***
-
-[initial zypper dup required](https://github.com/rockstor/rockstor-website/issues/71)

--- a/content/dls/Tumbleweed_ARM64EFI.md
+++ b/content/dls/Tumbleweed_ARM64EFI.md
@@ -8,7 +8,7 @@ os: "Tumbleweed"
 os_weight: 42
 machine: "ARM64EFI"
 arch: "aarch64"
-rpm_version: "4.5.8"
+rpm_version: "5.0.9"
 rpm_release: "0"
 installer_patch: ""
 ---

--- a/content/dls/Tumbleweed_RaspberryPi4.md
+++ b/content/dls/Tumbleweed_RaspberryPi4.md
@@ -13,6 +13,8 @@ rpm_release: "0"
 installer_patch: ""
 ---
 
+--- **REBOOT BUG:** [Pi4 installer fails on reboot](https://github.com/rockstor/rockstor-core/issues/2843) ---
+
 ***Development/Advanced-user/Rescue use only***
 
-[initial zypper dup required](https://github.com/rockstor/rockstor-website/issues/71)
+*Also Pi 400 compatible and possibly Pi5 with future updates*

--- a/content/dls/Tumbleweed_RaspberryPi4.md
+++ b/content/dls/Tumbleweed_RaspberryPi4.md
@@ -8,7 +8,7 @@ os: "Tumbleweed"
 os_weight: 41
 machine: "RaspberryPi4"
 arch: "aarch64"
-rpm_version: "4.5.8"
+rpm_version: "5.0.9"
 rpm_release: "0"
 installer_patch: ""
 ---

--- a/content/dls/Tumbleweed_x86_64.md
+++ b/content/dls/Tumbleweed_x86_64.md
@@ -14,5 +14,3 @@ installer_patch: ""
 ---
 
 ***Development/Advanced-user/Rescue use only***
-
-[initial zypper dup required](https://github.com/rockstor/rockstor-website/issues/71)

--- a/content/dls/Tumbleweed_x86_64.md
+++ b/content/dls/Tumbleweed_x86_64.md
@@ -8,7 +8,7 @@ os: "Tumbleweed"
 os_weight: 40
 machine: "generic"
 arch: "x86_64"
-rpm_version: "4.5.8"
+rpm_version: "5.0.9"
 rpm_release: "0"
 installer_patch: ""
 ---

--- a/content/dls/_index.md
+++ b/content/dls/_index.md
@@ -37,7 +37,7 @@ latest/last 'rockstor' package version published, per channel, per Leap version
 
 ---
 
-*We are now Pi4 & ARM64 [Embedded Boot](https://github.com/ARM-software/ebbr) / [Server Boot](https://github.com/ARM-software/sbsa-acs) compatible.*
+*We are Pi4 & ARM64 [Embedded Boot](https://github.com/ARM-software/ebbr) / [Server Boot](https://github.com/ARM-software/sbsa-acs) compatible.*
 
 See our [Rockstor’s “Built on openSUSE” installer](/docs/installation/installer-howto.html) and 
 [Making a Rockstor USB install disk](/docs/installation/quickstart.html#making-a-rockstor-usb-install-disk)

--- a/content/dls/_index.md
+++ b/content/dls/_index.md
@@ -12,19 +12,32 @@ cascade:
     render: false
 ---
 ---
-{{< center-this >}}
-## Install using the options below.
+### Installers include first Stable or RC* status 'rockstor' packages.
 
-## "Built on openSUSE" installers are Stable or RC* status.
+***Rockstor 5.0.9-0 = Stable Release Candidate (RC4)***
 
-***Rockstor 4.5.8-0 = Stable Release Candidate (RC5)***
+[Stable Release Candidate status](https://forum.rockstor.com/t/v5-0-testing-channel-changelog/8898/18) **---**
+[GitHub Milestone](https://github.com/rockstor/rockstor-core/milestone/27)
 
-[Stable Release Candidate status](https://forum.rockstor.com/t/v4-5-testing-channel-changelog/8546/10) **---**
-[GitHub Milestone](https://github.com/rockstor/rockstor-core/milestone/19)
+*4.1.0-0 was our first "Built on openSUSE" Stable Release*
 
-*Rockstor 4.1.0-0 = First "Built on openSUSE" Stable Release*
+*4.6.0-0 was our "First Stable Poetry build" - with a 4.6.1-0 hot-patch*
 
-*Rockstor 4 is now also Pi4 & ARM64 [Embedded Boot](https://github.com/ARM-software/ebbr) / [Server Boot](https://github.com/ARM-software/sbsa-acs) compatible.*
+*5.1.X-X (pending) "Major Python/Django update"*
+
+latest/last 'rockstor' package version published, per channel, per Leap version
+
+{{< bootstrap-table table_class="table table-bordered border-primary table-striped" >}}
+| ---     | 15.1    | 15.2    | 15.3    | 15.4    | 15.5    | 15.6    |
+|---------|---------|---------|---------|---------|---------|---------|
+| Testing | 4.0.1-0 | 4.1.0-0 | 4.6.1-0 | 5.0.9-0 | 5.0.9-0 | 5.0.9-0 |
+| Stable  | ---     | 4.1.0-0 | 4.1.0-0 | 4.6.1-0 | 4.6.1-0 | ---     |
+{{< /bootstrap-table >}}
+
+
+---
+
+*We are now Pi4 & ARM64 [Embedded Boot](https://github.com/ARM-software/ebbr) / [Server Boot](https://github.com/ARM-software/sbsa-acs) compatible.*
 
 See our [Rockstor’s “Built on openSUSE” installer](/docs/installation/installer-howto.html) and 
 [Making a Rockstor USB install disk](/docs/installation/quickstart.html#making-a-rockstor-usb-install-disk)
@@ -32,5 +45,4 @@ docs section.
 
 See also: [Migrating from Legacy V3 to V4 “Built on openSUSE”](/docs/howtos/v3_to_v4.html). 
 
-**Preferred options appear higher up in the following list.**
-{{< /center-this >}}
+**Preferred options appear first in the following list.**

--- a/content/dls/diy.md
+++ b/content/dls/diy.md
@@ -8,18 +8,18 @@ os: "diy"
 os_weight: 40
 machine: "generic|RaspberryPi4|ARM64EFI"
 arch: "x86_64|aarch64"
-rpm_version: "4.1.0"
+rpm_version: "5.0.9"
 rpm_release: "0"
 installer_patch: ""
 ---
 
 All our "Built on openSUSE" installers are made using the [Rockstor 4 Installer Recipe](https://github.com/rockstor/rockstor-installer).
 This in-turn uses the excellent [Kiwi-ng](https://github.com/OSInside/kiwi) open source image and appliance builder from openSUSE.
-See [Kiwi-ng's docs](https://osinside.github.io/kiwi/) for the possibilities.
+[Kiwi-ng's docs](https://osinside.github.io/kiwi/).
 
 You can also create your own custom profile tailored to your specific needs.
 Please see our [Custom Solutions]({{< relref customizable-btrfs-nas-storage-platform.md >}}) for context.
 
-All pending upstream updates, at time of installer build/re-build, are pre-applied to the resulting image.
+All upstream updates, at installer build/re-build date/time, are pre-applied to the resulting image.
 
-*We welcome profile contributions where our existing profiles are insufficient.* 
+***We welcome profile contributions where our existing profiles are insufficient.*** 

--- a/content/dls/rpm.md
+++ b/content/dls/rpm.md
@@ -8,12 +8,12 @@ os: "rpm"
 os_weight: 40
 machine: "generic"
 arch: "x86_64"
-rpm_version: "4.5.8"
+rpm_version: "5.0.9"
 rpm_release: "0"
 installer_patch: ""
 ---
 
-For the advanced rpm only install method 
+**Development/Advanced-user, rpm only, install method.**
 
 ***See our [Install on Vanilla openSUSE/SuSE SLES](https://rockstor.com/docs/howtos/rpm_install.html) How-to.***
 

--- a/layouts/dls/download-entry.html
+++ b/layouts/dls/download-entry.html
@@ -28,7 +28,7 @@
 
       {{ else if strings.HasSuffix $dlfilename "xz" }}
 
-      {{ index $installermap "xz" }} {{ $dlfilename }} | dd bs=4M of=/dev/sdX iflag=fullblock conv=notrunc status=progress
+      {{ index $installermap "xz" }} {{ $dlfilename }} | sudo dd bs=4M of=/dev/sdX iflag=fullblock conv=notrunc status=progress
 
       {{ end }} </strong>
 


### PR DESCRIPTION
Remove EOL Leap entries, and add 15.5 & 15.6 entries. Update all relevant installer entries to reflect latest 'rockstor' Stable RC based versions (late testing phase).

# Includes
- Table for 'rockstor' pkg version published per channel, per leap version.
- 15.6 entries have pre-release/follow-up warning/note.
- Formatting/wording improvements.

Fixes #87 