### PR TITLE
Update EULA page re installer #105

### DIFF
--- a/content/eula.md
+++ b/content/eula.md
@@ -1,6 +1,6 @@
 ---
 title: "Rockstor End User Licence Agreement (EULA)"
-date: 2023-03-08T12:00:00+01:00
+date: 2024-11-22T12:00:00+01:00
 draft: false
 ---
 
@@ -12,33 +12,34 @@ The Rockstor package is licensed:
 
 ---
 ## Our "Built on openSUSE" Installer EULA
-The following is a Trademarks search/replace of our upstream (openSUSE) GPLv2 license.
-And is the same as that displayed / agreed-to during our [kiwi-ng](https://github.com/OSInside/kiwi) created installer.
-See the following file in our [rockstor-installer](https://github.com/rockstor/rockstor-installer/blob/master/config.sh) repository.
+The following is a Trademarks aware automated edit of our upstreams/openSUSE's GPLv2 prevalent license.
+Versioning may vary to that displayed/agreed-to during our [kiwi-ng](https://github.com/OSInside/kiwi) created installer.
+See [rockstor-installer's config.sh](https://github.com/rockstor/rockstor-installer/blob/master/config.sh) for automation details.
 
 As indicated in [openSUSE:Trademark guidelines](https://en.opensuse.org/openSUSE:Trademark_guidelines) we are required to make these changes.
-We are also required to use one of the given terms when referencing our upstream: we have chosen to use: **Built on openSUSE** & **Uses openSUSE**.
-Examples of this use during the installer can be seen in our [Rockstor’s “Built on openSUSE” installer](https://rockstor.com/docs/installation/installer-howto.html) document section.
+We are also required to use one of the given terms when referencing our upstream.
+The chosen terms are: **Built on openSUSE** & **Uses openSUSE**.
+For examples of these terms' use, within our installer & Web-UI, see: [Rockstor’s “Built on openSUSE” installer](https://rockstor.com/docs/installation/installer-howto.html).
 
 We thank openSUSE / SuSE and the wider open source community for such excellent resources as the Leap base OS we use, [kiwk-ng](https://github.com/OSInside/kiwi), and the [Open Build Service (OBS)](https://build.opensuse.org/).
 
 ---
 
 LICENSE AGREEMENT
-Rockstor® Leap 15.4
+Rockstor "Built on openSUSE" Leap 15.6
 
 This agreement governs your download, installation, or use
-of Rockstor Leap 15.4 and its updates, regardless of the delivery
-mechanism. Rockstor Leap 15.4 is a collective work under US Copyright
+of Rockstor "Built on openSUSE" Leap 15.6 and its updates, regardless of the delivery
+mechanism. Rockstor "Built on openSUSE" Leap 15.6 is a collective work under US Copyright
 Law. Subject to the following terms, The Rockstor Project grants to
 you a license to this collective work pursuant to the GNU General
 Public License version 2. By downloading, installing, or using
-Rockstor Leap 15.4, you agree to the terms of this agreement.
+Rockstor "Built on openSUSE" Leap 15.6, you agree to the terms of this agreement.
 
-Rockstor Leap 15.4 is a modular Linux operating system consisting of
+Rockstor "Built on openSUSE" Leap 15.6 is a modular Linux operating system consisting of
 hundreds of software components. The license agreement for each
 component is generally located in the component's source code. With
-the exception of certain files containing the “Rockstor”
+the exception of certain files containing the “openSUSE”
 trademark discussed below, the license terms for the components
 permit you to copy and redistribute the component. With the
 potential exception of certain firmware files, the license terms
@@ -47,61 +48,61 @@ component, in both source code and binary code forms. This agreement
 does not limit your rights under, or grant you rights that supersede,
 the license terms of any particular component.
 
-Rockstor Leap 15.4 and each of its components, including the source
+Rockstor "Built on openSUSE" Leap 15.6 and each of its components, including the source
 code, documentation, appearance, structure, and organization, are
 copyrighted by The Rockstor Project and others and are protected under
-copyright and other laws. Title to Rockstor Leap 15.4 and any
+copyright and other laws. Title to Rockstor "Built on openSUSE" Leap 15.6 and any
 component, or to any copy, will remain with the aforementioned or its
-licensors, subject to the applicable license. The "Rockstor" trademark
-is a trademark of Rockstor, Inc. in the US and other countries and is
+licensors, subject to the applicable license. The "openSUSE" trademark
+is a trademark of SUSE, LLC. in the US and other countries and is
 used by permission. This agreement permits you to distribute
-unmodified or modified copies of Rockstor Leap 15.4 using the
-“Rockstor” trademark on the condition that you follow The Rockstor
+unmodified or modified copies of Rockstor "Built on openSUSE" Leap 15.6 using the
+“openSUSE” trademark on the condition that you follow The openSUSE
 Project’s trademark guidelines located at
-https://rockstor.com/legal.html. You must abide by these trademark
-guidelines when distributing Rockstor Leap 15.4, regardless of whether
-Rockstor Leap 15.4 has been modified.
+http://en.opensuse.org/Legal. You must abide by these trademark
+guidelines when distributing Rockstor "Built on openSUSE" Leap 15.6, regardless of whether
+Rockstor "Built on openSUSE" Leap 15.6 has been modified.
 
 Except as specifically stated in this agreement or a license for
 a particular component, TO THE MAXIMUM EXTENT PERMITTED UNDER
-APPLICABLE LAW, ROCKSTOR Leap 15.4 AND THE COMPONENTS ARE PROVIDED
+APPLICABLE LAW, Rockstor "Built on openSUSE" Leap 15.6 AND THE COMPONENTS ARE PROVIDED
 AND LICENSED "AS IS" WITHOUT WARRANTY OF ANY KIND, EXPRESSED OR
 IMPLIED, INCLUDING THE IMPLIED WARRANTIES OF MERCHANTABILITY, TITLE,
-NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE. The Rockstor
-Project does not warrant that the functions contained in Rockstor
-Leap 15.4 will meet your requirements or that the operation of Rockstor
-Leap 15.4 will be entirely error free or appear precisely as described
-in the accompanying documentation. USE OF ROCKSTOR Leap 15.4 IS AT YOUR
+NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE. The openSUSE
+Project does not warrant that the functions contained in openSUSE
+Leap 15.6 will meet your requirements or that the operation of openSUSE
+Leap 15.6 will be entirely error free or appear precisely as described
+in the accompanying documentation. USE OF Rockstor "Built on openSUSE" Leap 15.6 IS AT YOUR
 OWN RISK.
 
 TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE ROCKSTOR
 PROJECT (AND ITS LICENSORS, SUBSIDIARIES, AND EMPLOYEES) WILL NOT
 BE LIABLE TO YOU FOR ANY DAMAGES, INCLUDING DIRECT, INCIDENTAL,
 OR CONSEQUENTIAL DAMAGES, LOST PROFITS, OR LOST SAVINGS ARISING OUT
-OF THE USE OR INABILITY TO USE ROCKSTOR Leap 15.4, EVEN IF THE ROCKSTOR
+OF THE USE OR INABILITY TO USE Rockstor "Built on openSUSE" Leap 15.6, EVEN IF THE ROCKSTOR
 PROJECT HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.  IN A
 JURISDICTION THAT LIMITS THE EXCLUSION OR LIMITATION OF DAMAGES,
 THE ROCKSTOR PROJECT’S (AND ITS LICENSORS’, SUBSIDIARIES’, AND
-EMPLOYEES’) AGGREGATE LIABILITY IS LIMITED TO 1ST SUBSCRIPTION PAYED, OR IF SUCH A
+EMPLOYEES’) AGGREGATE LIABILITY IS LIMITED TO 1ST STABLE UPDATES SUBSCRIPTION PAYED, OR IF SUCH A
 LIMITATION IS NOT ALLOWED, IS LIMITED TO THE MAXIMUM EXTENT ALLOWED.
 
-You acknowledge that Rockstor Leap 15.4 is subject to the U.S. Export
+You acknowledge that Rockstor "Built on openSUSE" Leap 15.6 is subject to the U.S. Export
 Administration Regulations (the “EAR”) and you agree to comply with the
-EAR.  You will not export or re-export Rockstor Leap 15.4 directly or
+EAR.  You will not export or re-export Rockstor "Built on openSUSE" Leap 15.6 directly or
 indirectly, to: (1) any countries that are subject to US export
 restrictions; (2) any end user who you know or have reason to know will
-utilize Rockstor Leap 15.4 in the design, development or production of
+utilize Rockstor "Built on openSUSE" Leap 15.6 in the design, development or production of
 nuclear, chemical or biological weapons, or rocket systems, space launch
 vehicles, and sounding rockets, or unmanned air vehicle systems, except
 as authorized by the relevant government agency by regulation or specific
 license; or (3) any end user who has been prohibited from participating in
 the US export transactions by any federal agency of the US government. By
-downloading or using Rockstor Leap 15.4, you are agreeing to the foregoing
+downloading or using Rockstor "Built on openSUSE" Leap 15.6, you are agreeing to the foregoing
 and you are representing and warranting that You are not located in,under
 the control of, or a national or resident of any such country or on any
 such list. In addition, you are responsible for complying with any local laws
 in Your jurisdiction which may impact Your right to import, export or use
-Rockstor Leap 15.4.  Please consult the Bureau of Industry and Security web
+Rockstor "Built on openSUSE" Leap 15.6.  Please consult the Bureau of Industry and Security web
 page www.bis.doc.gov before exporting items subject to the EAR. It is your
 responsibility to obtain any necessary export approvals.
 
@@ -123,8 +124,8 @@ is subject to the restrictions in FAR 52.227-14 (Dec 2007)
 Alternate III (Dec 2007), FAR  52.227-19 (Dec 2007), or DFARS
 252.227-7013(b)(3) (Nov 1995), or applicable successor clauses.
 
-Copyright © 2012-2023 The Rockstor Project. All rights
-reserved. "Store Smartly" and "Rockstor" are registered trademarks of Rockstor, Inc.,
-or its affiliates, which founded, sponsors, and is designated by, The Rockstor
+Copyright © 2024 The Rockstor Project. All rights
+reserved. "SUSE" and "openSUSE" are registered trademarks of SUSE LLC,
+or its affiliates, which founded, sponsors, and is designated by, The openSUSE
 Project. "Linux" is a registered trademark of Linus Torvalds. All
 other trademarks are the property of their respective owners.


### PR DESCRIPTION
Drop "Rockstor Leap 15.4" nomenclature in favour of the more representative 'Rockstor "Built on openSUSE" Leap 15.6'.

Fixes #105 

These changes are intended to normalise our reference re our base OS, and to hopefully better adhere to the upstream guidelines as per:
- https://en.opensuse.org/openSUSE:Trademark_guidelines

N.B. in-file formatting, within EULA section, intentionally follows that of the original, as presented to the end-user during install.

Includes
- Copyright date update.
- Specify 'Stable Updates' as Subscription type: we have others.
- Acknowledge version differences.
- Remove now redundant references.
- Minor EULA section introduction/pre-able rewording.
- Preserve underlying references to "The openSUSE Project".
- Preserve "SUSE" & "openSUSE" trademarks attribution: SUSE LLC.
- Preserve upstreams legal reference given our "Built on ..." status.