### PR TITLE
Remove near EOL "Built on openSUSE" Leap 15.5 installers #104

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -157,7 +157,7 @@ author = "See: AUTHORS file."
 # Website copyright notice (markdownify)
 copyright = "Copyright &copy; 2024 The Rockstor Project"
 # use lowercase version of frontmatter os
-downloads_os_order = ["leap15.6", "leap15.5", "tumbleweed", "diy", "rpm", "centos7.1511"]
+downloads_os_order = ["leap15.6", "tumbleweed", "diy", "rpm", "centos7.1511"]
 
 # CSS Plugins
 [[params.plugins.css]]


### PR DESCRIPTION
As per https://en.opensuse.org/Lifetime openSUSE Leap 15.5 is close to EOL. Given limited resources and our having promoted 15.6 based downloadable installers since 15.6 beta release 5 months ago, remove 15.5 entries to clear the way for rebuilt installers based on the remaining non legacy targets, and non beta release 15.6.

Fixes #104 