### PR TITLE
Update Downloads page re 5.0.15 RC10 installer uploads #108

### DIFF
--- a/content/dls/Leap15-6_ARM64EFI.md
+++ b/content/dls/Leap15-6_ARM64EFI.md
@@ -1,6 +1,6 @@
 ---
 title: "Leap15 6_ARM64EFI"
-date: 2023-01-26T17:21:01+01:00
+date: 2024-11-26T17:21:01+01:00
 draft: false
 icon: "fa-brands fa-linux"
 download-base: "/"
@@ -8,9 +8,7 @@ os: "Leap15.6"
 os_weight: 42
 machine: "ARM64EFI"
 arch: "aarch64"
-rpm_version: "5.0.9"
+rpm_version: "5.0.15"
 rpm_release: "0"
 installer_patch: ""
 ---
-
-**WARNING: Built using pre-release Leap 15.6** *- will require 'zypper dup' post 15.6 release -*

--- a/content/dls/Leap15-6_RaspberryPi4.md
+++ b/content/dls/Leap15-6_RaspberryPi4.md
@@ -1,6 +1,6 @@
 ---
 title: "Leap15 6_RaspberryPi4"
-date: 2023-01-26T17:20:03+01:00
+date: 2024-11-26T17:20:03+01:00
 draft: false
 icon: "fa-brands fa-linux"
 download-base: "/"
@@ -8,13 +8,7 @@ os: "Leap15.6"
 os_weight: 41
 machine: "RaspberryPi4"
 arch: "aarch64"
-rpm_version: "5.0.9"
+rpm_version: "5.0.15"
 rpm_release: "0"
 installer_patch: ""
 ---
-
---- **REBOOT BUG:** [Pi4 installer fails on reboot](https://github.com/rockstor/rockstor-core/issues/2843) ---
-
-**WARNING: Built using pre-release Leap 15.6** *- will require 'zypper dup' post 15.6 release -*
-
-*Also Pi 400 compatible*

--- a/content/dls/Leap15-6_x86_64.md
+++ b/content/dls/Leap15-6_x86_64.md
@@ -1,6 +1,6 @@
 ---
 title: "Leap15 6_x86_64"
-date: 2023-01-26T15:00:42+01:00
+date: 2024-11-26T15:00:42+01:00
 draft: false
 icon: "fa-brands fa-linux"
 download-base: "/"
@@ -8,12 +8,9 @@ os: "Leap15.6"
 os_weight: 40
 machine: "generic"
 arch: "x86_64"
-rpm_version: "5.0.9"
+rpm_version: "5.0.15"
 rpm_release: "0"
 installer_patch: ""
 ---
 
 **Recommended**
-
-**WARNING: Built using pre-release Leap 15.6** *- will require 'zypper dup' post 15.6 release -*
-

--- a/content/dls/Tumbleweed_ARM64EFI.md
+++ b/content/dls/Tumbleweed_ARM64EFI.md
@@ -1,6 +1,6 @@
 ---
 title: "Tumbleweed_ARM64EFI"
-date: 2023-03-18T16:45:48Z
+date: 2024-11-26T16:45:48Z
 draft: false
 icon: "fa-brands fa-linux"
 download-base: "/"
@@ -8,7 +8,7 @@ os: "Tumbleweed"
 os_weight: 42
 machine: "ARM64EFI"
 arch: "aarch64"
-rpm_version: "5.0.9"
+rpm_version: "5.0.15"
 rpm_release: "0"
 installer_patch: ""
 ---

--- a/content/dls/Tumbleweed_RaspberryPi4.md
+++ b/content/dls/Tumbleweed_RaspberryPi4.md
@@ -1,6 +1,6 @@
 ---
 title: "Tumbleweed_RaspberryPi4"
-date: 2023-03-18T16:46:10Z
+date: 2024-11-26T16:46:10Z
 draft: false
 icon: "fa-brands fa-linux"
 download-base: "/"
@@ -8,13 +8,9 @@ os: "Tumbleweed"
 os_weight: 41
 machine: "RaspberryPi4"
 arch: "aarch64"
-rpm_version: "5.0.9"
+rpm_version: "5.0.15"
 rpm_release: "0"
 installer_patch: ""
 ---
 
---- **REBOOT BUG:** [Pi4 installer fails on reboot](https://github.com/rockstor/rockstor-core/issues/2843) ---
-
 ***Development/Advanced-user/Rescue use only***
-
-*Also Pi 400 compatible and possibly Pi5 with future updates*

--- a/content/dls/Tumbleweed_x86_64.md
+++ b/content/dls/Tumbleweed_x86_64.md
@@ -1,6 +1,6 @@
 ---
 title: "Tumbleweed_x86_64"
-date: 2023-03-18T16:45:05Z
+date: 2024-11-26T16:45:05Z
 draft: false
 icon: "fa-brands fa-linux"
 download-base: "/"
@@ -8,7 +8,7 @@ os: "Tumbleweed"
 os_weight: 40
 machine: "generic"
 arch: "x86_64"
-rpm_version: "5.0.9"
+rpm_version: "5.0.15"
 rpm_release: "0"
 installer_patch: ""
 ---

--- a/content/dls/_index.md
+++ b/content/dls/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Downloads"
-date: 2023-01-26T18:54:52+01:00
+date: 2024-11-27T18:54:52+01:00
 draft: false
 aliases:
     - /download.html
@@ -14,23 +14,23 @@ cascade:
 ---
 ### Installers include first Stable or RC* status 'rockstor' packages.
 
-***Rockstor 5.0.9-0 = Stable Release Candidate (RC4)***
+***Rockstor 5.0.15-0 = Stable Release Candidate (RC10)***
 
-[Stable Release Candidate status](https://forum.rockstor.com/t/v5-0-testing-channel-changelog/8898/18) **---**
+[Stable Release Candidate status](https://forum.rockstor.com/t/v5-0-testing-channel-changelog/8898/29) **---**
 [GitHub Milestone](https://github.com/rockstor/rockstor-core/milestone/27)
 
 *4.1.0-0 was our first "Built on openSUSE" Stable Release*
 
 *4.6.0-0 was our "First Stable Poetry build" - with a 4.6.1-0 hot-patch*
 
-*5.1.X-X (pending) "Major Python/Django update"*
+*5.1.X-X (Pending) is a "Major Python/Django update"*
 
-latest/last 'rockstor' package version published, per channel, per Leap version
+Latest/last 'rockstor' package version published, per channel, per Leap version
 
 {{< bootstrap-table table_class="table table-bordered border-primary table-striped" >}}
 | ---     | 15.1    | 15.2    | 15.3    | 15.4     | 15.5     | 15.6     |
 |---------|---------|---------|---------|----------|----------|----------|
-| Testing | 4.0.1-0 | 4.1.0-0 | 4.6.1-0 | 5.0.14-0 | 5.0.14-0 | 5.0.14-0 |
+| Testing | 4.0.1-0 | 4.1.0-0 | 4.6.1-0 | 5.0.15-0 | 5.0.15-0 | 5.0.15-0 |
 | Stable  | ---     | 4.1.0-0 | 4.1.0-0 | 4.6.1-0  | 4.6.1-0  | Pending  |
 {{< /bootstrap-table >}}
 
@@ -43,6 +43,7 @@ See our [Rockstor’s “Built on openSUSE” installer](/docs/installation/inst
 [Making a Rockstor USB install disk](/docs/installation/quickstart.html#making-a-rockstor-usb-install-disk)
 docs section.
 
-See also: [Migrating from Legacy V3 to V4 “Built on openSUSE”](/docs/howtos/v3_to_v4.html). 
+See also: [Migrating Legacy v3 (CentOS) to “Built on openSUSE”](/docs/howtos/centos_to_opensuse.html)
+and our complete set of: [Distribution update from 15.* to 15.* how-tos](https://rockstor.com/docs/howtos.html).
 
 **Preferred options appear first in the following list.**


### PR DESCRIPTION
Update top-of-page text re versions and forum reference plus some minor rewording. Add a reference & link to the in-place update how-tos, along with a minor change re our recent renaming of the CentOS to 'Build on openSUSE' migration how-to.

All previous provisos were removed as they no longer pertain to this most recent installer set.

Fixes #108 

---

This pull request has the following dependency:

- Update EULA page re installer #105 #107

As our Web-UI content will then reflect what these new installers present.