### PR TITLE
Update Downloads page re CentOS repo removals #122

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -157,7 +157,7 @@ author = "See: AUTHORS file."
 # Website copyright notice (markdownify)
 copyright = "Copyright &copy; 2025 The Rockstor Project"
 # use lowercase version of frontmatter os
-downloads_os_order = ["leap15.6", "tumbleweed", "slowroll", "diy", "rpm", "centos7.1511"]
+downloads_os_order = ["leap15.6", "tumbleweed", "slowroll", "diy", "rpm"]
 
 # CSS Plugins
 [[params.plugins.css]]

--- a/content/dls/CentOS7-1511_x86_64.md
+++ b/content/dls/CentOS7-1511_x86_64.md
@@ -1,7 +1,7 @@
 ---
 title: "CentOS 7 1511"
 date: 2017-07-02T13:09:11+01:00
-draft: false
+draft: True
 icon: "fa-brands fa-linux"
 download-base: "/"
 os: "CentOS7.1511"
@@ -15,9 +15,11 @@ installer_patch: ""
 
 Legacy / Unsupported installer from 2017. Available here only for specialist purposes.
 
-Also available on SourceForge as [Rockstor-3.9.1.iso](https://sourceforge.net/projects/rockstor/files/)
+[Forum announcement](https://forum.rockstor.com/t/announcing-rockstor-3-9-1/3452)
 
-**DO NOT USE FOR NEW INSTALLS.**
+**DO NOT USE FOR NEW INSTALLATIONS: CentOS was EOL 30th June 2024.**
 
-- Last Testing Channel release (3.9.1-16) - November 2017
-- Last Stable channel released (3.9.2-57) - April 2020 
+**As from June 2025 Testing & Stable Repositories no longer exist**
+
+- Last Testing Channel release ([3.9.1-16](http://updates.rockstor.com:8999/rockstor-testing/rockstor-3.9.1-16.x86_64.rpm)) - November 2017
+- Last Stable channel released ([3.9.2-57](http://updates.rockstor.com:8999/rockstor-stable/rockstor-3.9.2-57.x86_64.rpm)) - April 2020


### PR DESCRIPTION
Typo fix, plus links added to last rpms published, per channel; given the associated CentOS repositories have now been removed. This removal dates to around 1 year-on from upstreams own EOL for this distribution.

Fixes #122 

- Remove SourceForge link.
- Add Forum announcement link.
- Add Upstream EOL date.
- Add our own repo removal date.
- Un-publish entry via draft mechanism & config.toml.

---

Contents were changed for archival purposes. I.e. to record the EOL dates.