### PR TITLE
Surface downloadable installers build dates #123

### DIFF
--- a/layouts/dls/download-entry.html
+++ b/layouts/dls/download-entry.html
@@ -10,7 +10,10 @@
       {{ if $dlfilename }}
 
       {{ if strings.HasSuffix $dlfilename "qcow2" }}<p/>
-      <p/>Also pre-sized (16GB) qcow2 format:<br/> {{end}}
+        <p/>Also pre-sized (16GB) qcow2 format:<br/>
+      {{ else }}
+        Built: {{ $.Date | time.Format ":date_medium" }}<p/>
+      {{ end }}
 
       {{ range $index,$extension := (slice "" ".sha256") }}
 


### PR DESCRIPTION
Modify dynamic download entry generation to include content page front-matter (metadata) date, which has already been set to the appropriate installer build date (but not time).

Fixes #123 