### PR TITLE
Forum maintenance sysalert #128

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ there is also a `sysalert` archetype.
 
 Intended to indicate ongoing maintenance associated with expected service outages. 
 These alerts appear, via their own partial layout, as an index page header.
-The default expiration period, set via the archetype, is creation data-time plus 24 hours.
+The default expiration period, set via the archetype, is creation data-time plus 48 hours.
 
 Example:
 

--- a/archetypes/sysalerts.md
+++ b/archetypes/sysalerts.md
@@ -3,7 +3,7 @@ title: "{{ replace .Name "-" " " | title }}"
 date: {{ .Date }}
 draft: false
 #add years months days
-expirydate: {{ now.AddDate 0 0 1 }}
+expirydate: {{ now.AddDate 0 0 2 }}
 ---
 {{< param title >}}
 under maintenance.

--- a/content/sysalerts/forum.md
+++ b/content/sysalerts/forum.md
@@ -1,9 +1,9 @@
 ---
 title: "Forum"
-date: 2025-01-16T14:01:12Z
+date: 2025-07-24T11:10:53+01:00
 draft: false
 #add years months days
-expirydate: 2025-01-17 14:01:12.330425232 +0000 WET
+expirydate: 2025-07-26 11:10:53.399738615 +0100 WEST
 ---
 {{< param title >}}
 under maintenance.


### PR DESCRIPTION
Refresh alert re forum maintenance.
Changes default intermittent service time to now plus 48 hours. Updates README.md re archetype change in sys-alert.

Closes #128 