### PR TITLE
Update 'About us' re fiscal host upstream name-change #133

### DIFF
--- a/content/about-us.md
+++ b/content/about-us.md
@@ -13,7 +13,7 @@ We are supported by our contributors, and fiscally hosted by [Open Source Europe
 
 *Founder & prior Maintainer: Suman Chakravartula - Domain and [trademarks]({{< relref legal.md >}}) owner/admin.*
 
-*Current Maintainer: Philip Paul Guyton - Project lead, core developer, & release manager.*
+*Current Maintainer: Philip Paul Guyton - Project lead, core developer, and release manager.*
 
 Our websites & support email use the "rockstor" domain. But forum notifications uses the "linuxlines" domain.
 This mixed domain use should be resolved soon.


### PR DESCRIPTION
Link text changed from "Open Collective Europe" to "Open Source Europe (OSE)": in line with upstream.

Additional simplification in the same sentence re: "members/subscribers/contributors" to "contributors". This reads better and aligns us with the parlance used on our Open Collective page: e.g. "Our contributors". This also covers nicely code, doc, bug reporting etc contributors; who support the project by non-fiscal acts.

Fixes #133 