### PR TITLE
Update Downloads page rpm version table #144

### DIFF
--- a/content/dls/_index.md
+++ b/content/dls/_index.md
@@ -17,7 +17,7 @@ cascade:
 
 ***Rockstor 5.1.0-0 = Final Stable Release Candidate***
 
-[Stable Release Candidate status](https://forum.rockstor.com/t/v5-5-testing-channel-changelog/10895/3) **---**
+[Stable Release Candidate status](https://forum.rockstor.com/t/v5-5-testing-channel-changelog/10895/6) **---**
 [Current Milestone](https://github.com/rockstor/rockstor-core/milestone/31)
 
 *4.1.0-0 was our first "Built on openSUSE" Stable Release*
@@ -26,17 +26,17 @@ cascade:
 
 *5.1.0-0 is a "Major Python/Django update"*
 
-*5.6.0-0 is our "Backend prep for front-end modernisation"*
+*5.6.0-0 lines up for "Backend prep for front-end modernisation"*
 
 Latest/last 'rockstor' package version published, per channel, per OS version.
 TW/SR = Tumbleweed-Slowroll (Development/Advanced-user/Rescue use only).
 
 {{< bootstrap-table table_class="table table-bordered border-primary table-striped" >}}
-| ---     | 15.1 EOL| 15.2 EOL| 15.3 EOL| 15.4 EOL | 15.5 EOL | 15.6    | TW/SR   |
-|---------|---------|---------|---------|----------|----------|---------|---------|
-| Edge    | ---     | ---     | ---     | ---      | ---      | 5.5.1-0 | 5.5.1-0 |
-| Testing | 4.0.1-0 | 4.1.0-0 | 4.6.1-0 | 5.0.15-0 | 5.0.15-0 | 5.5.1-0 | 5.5.1-0 |
-| Stable  | ---     | 4.1.0-0 | 4.1.0-0 | 4.6.1-0  | 4.6.1-0  | 5.1.0-0 | 5.1.0-0 |
+| ---     | 15.1 EOL| 15.2 EOL| 15.3 EOL| 15.4 EOL | 15.5 EOL | 15.6 EOL| 16.0    | TW/SR   |
+|---------|---------|---------|---------|----------|----------|---------|---------|---------|
+| Edge    | ---     | ---     | ---     | ---      | ---      | 5.5.2-1 | 5.5.2-1 | 5.5.2-1 |
+| Testing | 4.0.1-0 | 4.1.0-0 | 4.6.1-0 | 5.0.15-0 | 5.0.15-0 | 5.5.2-1 | 5.5.2-1 | 5.5.2-1 |
+| Stable  | ---     | 4.1.0-0 | 4.1.0-0 | 4.6.1-0  | 4.6.1-0  | 5.1.0-0 |         | 5.1.0-0 |
 {{< /bootstrap-table >}}
 
 


### PR DESCRIPTION
Add our new Leap 16.0 repo and update available RPM package versions.

Fixes #144